### PR TITLE
Add keyboard shortcuts for common actions

### DIFF
--- a/src/components/AddTodoForm.tsx
+++ b/src/components/AddTodoForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, forwardRef, useImperativeHandle } from "react";
 import { Todo, Category } from "@/types/todo";
 
 const CATEGORIES: Category[] = ["Work", "Personal", "Shopping", "Health", "Other"];
@@ -14,67 +14,81 @@ interface AddTodoFormProps {
   ) => void;
 }
 
-export default function AddTodoForm({ onAdd }: AddTodoFormProps) {
-  const [title, setTitle] = useState("");
-  const [priority, setPriority] = useState<Todo["priority"]>("medium");
-  const [category, setCategory] = useState<Todo["category"] | "">("");
-  const [dueDate, setDueDate] = useState("");
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim()) return;
-    onAdd(title, priority, category || undefined, dueDate || undefined);
-    setTitle("");
-    setPriority("medium");
-    setCategory("");
-    setDueDate("");
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-      <div className="flex flex-col sm:flex-row gap-3">
-        <input
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="What needs to be done?"
-          className="flex-1 px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm"
-        />
-        <select
-          value={priority}
-          onChange={(e) => setPriority(e.target.value as Todo["priority"])}
-          className="px-3 py-3 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm"
-        >
-          <option value="low">🟢 Low</option>
-          <option value="medium">🟡 Medium</option>
-          <option value="high">🔴 High</option>
-        </select>
-        <button
-          type="submit"
-          disabled={!title.trim()}
-          className="px-6 py-3 bg-indigo-500 text-white font-semibold rounded-xl shadow-sm hover:bg-indigo-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        >
-          Add
-        </button>
-      </div>
-      <div className="flex flex-col sm:flex-row gap-3">
-        <select
-          value={category}
-          onChange={(e) => setCategory(e.target.value as Todo["category"] | "")}
-          className="flex-1 px-3 py-2.5 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm text-sm"
-        >
-          <option value="">📂 No category</option>
-          {CATEGORIES.map((c) => (
-            <option key={c} value={c}>{c}</option>
-          ))}
-        </select>
-        <input
-          type="date"
-          value={dueDate}
-          onChange={(e) => setDueDate(e.target.value)}
-          className="flex-1 px-3 py-2.5 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm text-sm"
-        />
-      </div>
-    </form>
-  );
+export interface AddTodoFormHandle {
+  focusInput: () => void;
 }
+
+const AddTodoForm = forwardRef<AddTodoFormHandle, AddTodoFormProps>(
+  function AddTodoForm({ onAdd }, ref) {
+    const [title, setTitle] = useState("");
+    const [priority, setPriority] = useState<Todo["priority"]>("medium");
+    const [category, setCategory] = useState<Todo["category"] | "">("");
+    const [dueDate, setDueDate] = useState("");
+    const titleInputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle(ref, () => ({
+      focusInput: () => titleInputRef.current?.focus(),
+    }));
+
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!title.trim()) return;
+      onAdd(title, priority, category || undefined, dueDate || undefined);
+      setTitle("");
+      setPriority("medium");
+      setCategory("");
+      setDueDate("");
+    };
+
+    return (
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <div className="flex flex-col sm:flex-row gap-3">
+          <input
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="What needs to be done?"
+            className="flex-1 px-4 py-3 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm"
+          />
+          <select
+            value={priority}
+            onChange={(e) => setPriority(e.target.value as Todo["priority"])}
+            className="px-3 py-3 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm"
+          >
+            <option value="low">🟢 Low</option>
+            <option value="medium">🟡 Medium</option>
+            <option value="high">🔴 High</option>
+          </select>
+          <button
+            type="submit"
+            disabled={!title.trim()}
+            className="px-6 py-3 bg-indigo-500 text-white font-semibold rounded-xl shadow-sm hover:bg-indigo-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+          >
+            Add
+          </button>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-3">
+          <select
+            value={category}
+            onChange={(e) => setCategory(e.target.value as Todo["category"] | "")}
+            className="flex-1 px-3 py-2.5 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm text-sm"
+          >
+            <option value="">📂 No category</option>
+            {CATEGORIES.map((c) => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+          <input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="flex-1 px-3 py-2.5 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm text-sm"
+          />
+        </div>
+      </form>
+    );
+  }
+);
+
+export default AddTodoForm;

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,191 +1,119 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useTodos } from "@/hooks/useTodos";
-import AddTodoForm from "./AddTodoForm";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import AddTodoForm, { AddTodoFormHandle } from "./AddTodoForm";
 import TodoItem from "./TodoItem";
 import ThemeToggle from "./ThemeToggle";
 import { Todo, Category } from "@/types/todo";
 
 type FilterType = "all" | "active" | "completed";
-
 const CATEGORIES: Category[] = ["Work", "Personal", "Shopping", "Health", "Other"];
-
-const CATEGORY_ICONS: Record<Category, string> = {
-  Work: "💼",
-  Personal: "👤",
-  Shopping: "🛒",
-  Health: "❤️",
-  Other: "📌",
-};
+const CATEGORY_ICONS: Record<Category, string> = { Work: "💼", Personal: "👤", Shopping: "🛒", Health: "❤️", Other: "📌" };
+const SHORTCUT_HINTS = [
+  { key: "N", action: "New todo" }, { key: "/", action: "Search" }, { key: "↑↓", action: "Navigate" },
+  { key: "Space", action: "Complete" }, { key: "E", action: "Edit" }, { key: "D", action: "Delete" }, { key: "Esc", action: "Clear" },
+];
 
 export default function TodoApp() {
   const { data: session } = useSession();
-  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } =
-    useTodos();
+  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } = useTodos();
   const [filter, setFilter] = useState<FilterType>("all");
   const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+  const [editingTodoId, setEditingTodoId] = useState<string | null>(null);
+  const addFormRef = useRef<AddTodoFormHandle>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const filteredTodos = useMemo(() => {
     return todos
       .filter((t) => {
-        const statusMatch =
-          filter === "active" ? !t.completed :
-          filter === "completed" ? t.completed :
-          true;
+        const statusMatch = filter === "active" ? !t.completed : filter === "completed" ? t.completed : true;
         const categoryMatch = categoryFilter === "all" || t.category === categoryFilter;
-        return statusMatch && categoryMatch;
+        const searchMatch = !searchQuery || t.title.toLowerCase().includes(searchQuery.toLowerCase());
+        return statusMatch && categoryMatch && searchMatch;
       })
       .sort((a, b) => {
-        // Items with due dates come before items without
         if (a.dueDate && !b.dueDate) return -1;
         if (!a.dueDate && b.dueDate) return 1;
-        // Both have due dates: sort soonest first
-        if (a.dueDate && b.dueDate) {
-          const diff = a.dueDate.localeCompare(b.dueDate);
-          if (diff !== 0) return diff;
-        }
-        // Fall back to creation date (newest first)
+        if (a.dueDate && b.dueDate) { const diff = a.dueDate.localeCompare(b.dueDate); if (diff !== 0) return diff; }
         return b.createdAt - a.createdAt;
       });
-  }, [todos, filter, categoryFilter]);
+  }, [todos, filter, categoryFilter, searchQuery]);
 
   const activeCount = todos.filter((t) => !t.completed).length;
   const completedCount = todos.filter((t) => t.completed).length;
+  const selectedTodo = selectedIndex >= 0 && selectedIndex < filteredTodos.length ? filteredTodos[selectedIndex] : null;
 
-  const filters: { label: string; value: FilterType }[] = [
-    { label: "All", value: "all" },
-    { label: "Active", value: "active" },
-    { label: "Completed", value: "completed" },
-  ];
+  const handleNewTodo = useCallback(() => { addFormRef.current?.focusInput(); setSelectedIndex(-1); setEditingTodoId(null); }, []);
+  const handleDelete = useCallback(() => { if (selectedTodo) { deleteTodo(selectedTodo.id); setSelectedIndex((prev) => Math.min(prev, filteredTodos.length - 2)); setEditingTodoId(null); } }, [selectedTodo, deleteTodo, filteredTodos.length]);
+  const handleEdit = useCallback(() => { if (selectedTodo) setEditingTodoId(selectedTodo.id); }, [selectedTodo]);
+  const handleSearch = useCallback(() => { searchInputRef.current?.focus(); setSelectedIndex(-1); setEditingTodoId(null); }, []);
+  const handleToggleComplete = useCallback(() => { if (selectedTodo) toggleTodo(selectedTodo.id); }, [selectedTodo, toggleTodo]);
+  const handleMoveUp = useCallback(() => { setEditingTodoId(null); setSelectedIndex((prev) => { if (filteredTodos.length === 0) return -1; if (prev <= 0) return filteredTodos.length - 1; return prev - 1; }); }, [filteredTodos.length]);
+  const handleMoveDown = useCallback(() => { setEditingTodoId(null); setSelectedIndex((prev) => { if (filteredTodos.length === 0) return -1; if (prev >= filteredTodos.length - 1) return 0; return prev + 1; }); }, [filteredTodos.length]);
+  const handleEscape = useCallback(() => { setSelectedIndex(-1); setEditingTodoId(null); setSearchQuery(""); if (document.activeElement instanceof HTMLElement) document.activeElement.blur(); }, []);
+
+  useKeyboardShortcuts({ onNewTodo: handleNewTodo, onDelete: handleDelete, onEdit: handleEdit, onSearch: handleSearch, onToggleComplete: handleToggleComplete, onMoveUp: handleMoveUp, onMoveDown: handleMoveDown, onEscape: handleEscape });
+
+  const filters: { label: string; value: FilterType }[] = [{ label: "All", value: "all" }, { label: "Active", value: "active" }, { label: "Completed", value: "completed" }];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50 py-12 px-4">
       <div className="max-w-xl mx-auto">
-        {/* Header */}
         <div className="mb-8">
           <div className="flex items-center justify-between mb-1">
-            <h1 className="text-4xl font-extrabold text-indigo-600 dark:text-indigo-400 tracking-tight">
-              ✅ Todo App
-            </h1>
+            <h1 className="text-4xl font-extrabold text-indigo-600 dark:text-indigo-400 tracking-tight">✅ Todo App</h1>
             <div className="flex items-center gap-3">
               <ThemeToggle />
-              {session?.user && (
-                <>
-                  <span className="text-sm text-gray-600 dark:text-gray-400">
-                    {session.user.name ?? session.user.email}
-                  </span>
-                  <button
-                    onClick={() => signOut({ callbackUrl: "/login" })}
-                    className="text-xs text-gray-400 hover:text-red-500 transition-colors"
-                  >
-                    Sign out
-                  </button>
-                </>
-              )}
+              {session?.user && (<><span className="text-sm text-gray-600 dark:text-gray-400">{session.user.name ?? session.user.email}</span><button onClick={() => signOut({ callbackUrl: "/login" })} className="text-xs text-gray-400 hover:text-red-500 transition-colors">Sign out</button></>)}
             </div>
           </div>
-          <p className="text-sm text-gray-500 dark:text-gray-400">
-            Your tasks, saved to your account
-          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400">Your tasks, saved to your account</p>
         </div>
 
-        {/* Add Form */}
-        <div className="mb-6">
-          <AddTodoForm onAdd={addTodo} />
+        <div className="mb-6"><AddTodoForm ref={addFormRef} onAdd={addTodo} /></div>
+
+        <div className="mb-4">
+          <div className="relative">
+            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
+            <input ref={searchInputRef} type="text" value={searchQuery} onChange={(e) => { setSearchQuery(e.target.value); setSelectedIndex(-1); }} placeholder='Search todos... (press "/" to focus)' className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-100 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-400 shadow-sm text-sm" />
+            {searchQuery && (<button onClick={() => setSearchQuery("")} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"><svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg></button>)}
+          </div>
         </div>
 
-        {/* Filter Tabs + Stats */}
         <div className="flex flex-col gap-2 mb-4">
           <div className="flex items-center justify-between">
             <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
-              {filters.map(({ label, value }) => (
-                <button
-                  key={value}
-                  onClick={() => setFilter(value)}
-                  className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                    filter === value
-                      ? "bg-white dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 shadow-sm"
-                      : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
-                  }`}
-                >
-                  {label}
-                </button>
-              ))}
+              {filters.map(({ label, value }) => (<button key={value} onClick={() => setFilter(value)} className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ${filter === value ? "bg-white dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 shadow-sm" : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"}`}>{label}</button>))}
             </div>
-            <span className="text-xs text-gray-400 dark:text-gray-500">
-              {activeCount} left
-            </span>
+            <span className="text-xs text-gray-400 dark:text-gray-500">{activeCount} left</span>
           </div>
-
-          {/* Category Filter */}
           <div className="flex flex-wrap gap-1">
-            <button
-              onClick={() => setCategoryFilter("all")}
-              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                categoryFilter === "all"
-                  ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
-                  : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-              }`}
-            >
-              📂 All
-            </button>
-            {CATEGORIES.map((cat) => (
-              <button
-                key={cat}
-                onClick={() => setCategoryFilter(cat)}
-                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                  categoryFilter === cat
-                    ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
-                    : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-                }`}
-              >
-                {CATEGORY_ICONS[cat]} {cat}
-              </button>
-            ))}
+            <button onClick={() => setCategoryFilter("all")} className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${categoryFilter === "all" ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300" : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"}`}>📂 All</button>
+            {CATEGORIES.map((cat) => (<button key={cat} onClick={() => setCategoryFilter(cat)} className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${categoryFilter === cat ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300" : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"}`}>{CATEGORY_ICONS[cat]} {cat}</button>))}
           </div>
         </div>
 
-        {/* Todo List */}
-        {!hydrated ? (
-          <div className="text-center py-16 text-gray-400">Loading…</div>
-        ) : filteredTodos.length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-gray-400 text-sm">
-              {filter === "completed"
-                ? "No completed todos yet."
-                : filter === "active"
-                ? "Nothing left to do!"
-                : "Add your first todo above!"}
-            </p>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            {filteredTodos.map((todo: Todo) => (
-              <div key={todo.id} className="todo-item-enter">
-                <TodoItem
-                  todo={todo}
-                  onToggle={toggleTodo}
-                  onDelete={deleteTodo}
-                  onEdit={editTodo}
-                />
+        {!hydrated ? (<div className="text-center py-16 text-gray-400">Loading…</div>)
+        : filteredTodos.length === 0 ? (<div className="text-center py-16"><p className="text-gray-400 text-sm">{searchQuery ? "No todos match your search." : filter === "completed" ? "No completed todos yet." : filter === "active" ? "Nothing left to do!" : "Add your first todo above!"}</p></div>)
+        : (<div className="flex flex-col gap-2">
+            {filteredTodos.map((todo: Todo, index: number) => (
+              <div key={todo.id} className="todo-item-enter cursor-pointer" onClick={() => { setSelectedIndex(index); setEditingTodoId(null); }}>
+                <TodoItem todo={todo} onToggle={toggleTodo} onDelete={deleteTodo} onEdit={editTodo} isSelected={index === selectedIndex} autoEdit={todo.id === editingTodoId} />
               </div>
             ))}
           </div>
         )}
 
-        {/* Footer actions */}
-        {completedCount > 0 && (
-          <div className="mt-4 flex justify-end">
-            <button
-              onClick={clearCompleted}
-              className="text-xs text-gray-400 hover:text-red-500 transition-colors"
-            >
-              Clear completed ({completedCount})
-            </button>
-          </div>
-        )}
+        {completedCount > 0 && (<div className="mt-4 flex justify-end"><button onClick={clearCompleted} className="text-xs text-gray-400 hover:text-red-500 transition-colors">Clear completed ({completedCount})</button></div>)}
+
+        <div className="mt-6 flex flex-wrap justify-center gap-2">
+          {SHORTCUT_HINTS.map(({ key, action }) => (<span key={key} className="text-xs text-gray-400 dark:text-gray-500"><kbd className="px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 font-mono text-gray-500 dark:text-gray-400">{key}</kbd>{" "}{action}</span>))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -15,13 +15,9 @@ interface TodoItemProps {
   todo: Todo;
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
-  onEdit: (
-    id: string,
-    title: string,
-    priority: Todo["priority"],
-    category?: Todo["category"],
-    dueDate?: string
-  ) => void;
+  onEdit: (id: string, title: string, priority: Todo["priority"], category?: Todo["category"], dueDate?: string) => void;
+  isSelected?: boolean;
+  autoEdit?: boolean;
 }
 
 function isOverdue(dueDate?: string): boolean {
@@ -34,12 +30,7 @@ function isDueToday(dueDate?: string): boolean {
   return dueDate === new Date().toISOString().split("T")[0];
 }
 
-export default function TodoItem({
-  todo,
-  onToggle,
-  onDelete,
-  onEdit,
-}: TodoItemProps) {
+export default function TodoItem({ todo, onToggle, onDelete, onEdit, isSelected = false, autoEdit = false }: TodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(todo.title);
   const [editPriority, setEditPriority] = useState<Todo["priority"]>(todo.priority);
@@ -47,27 +38,22 @@ export default function TodoItem({
   const [editDueDate, setEditDueDate] = useState(todo.dueDate ?? "");
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
+  useEffect(() => { if (autoEdit && !editing) setEditing(true); }, [autoEdit]);
 
   const saveEdit = () => {
     if (editTitle.trim()) {
       onEdit(todo.id, editTitle, editPriority, editCategory || undefined, editDueDate || undefined);
     } else {
-      setEditTitle(todo.title);
-      setEditPriority(todo.priority);
-      setEditCategory(todo.category ?? "");
-      setEditDueDate(todo.dueDate ?? "");
+      setEditTitle(todo.title); setEditPriority(todo.priority);
+      setEditCategory(todo.category ?? ""); setEditDueDate(todo.dueDate ?? "");
     }
     setEditing(false);
   };
 
   const cancelEdit = () => {
-    setEditTitle(todo.title);
-    setEditPriority(todo.priority);
-    setEditCategory(todo.category ?? "");
-    setEditDueDate(todo.dueDate ?? "");
+    setEditTitle(todo.title); setEditPriority(todo.priority);
+    setEditCategory(todo.category ?? ""); setEditDueDate(todo.dueDate ?? "");
     setEditing(false);
   };
 
@@ -76,67 +62,30 @@ export default function TodoItem({
 
   return (
     <li className={`flex items-start gap-3 p-4 rounded-xl shadow-sm border group transition-all hover:shadow-md ${
-      overdue
-        ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
+      overdue ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
+        : isSelected ? "bg-indigo-50 dark:bg-indigo-950 border-indigo-300 dark:border-indigo-700 ring-2 ring-indigo-400 dark:ring-indigo-500"
         : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
     }`}>
-      {/* Checkbox */}
-      <button
-        onClick={() => onToggle(todo.id)}
-        aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
+      <button onClick={() => onToggle(todo.id)} aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
         className={`flex-shrink-0 mt-0.5 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
-          todo.completed
-            ? "bg-indigo-500 border-indigo-500 text-white"
-            : "border-gray-300 hover:border-indigo-400"
-        }`}
-      >
-        {todo.completed && (
-          <svg className="w-3 h-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-          </svg>
-        )}
+          todo.completed ? "bg-indigo-500 border-indigo-500 text-white" : "border-gray-300 hover:border-indigo-400"}`}>
+        {todo.completed && (<svg className="w-3 h-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>)}
       </button>
-
-      {/* Content */}
       <div className="flex-1 min-w-0">
         {editing ? (
           <div className="flex flex-col gap-2">
-            <input
-              ref={inputRef}
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveEdit();
-                if (e.key === "Escape") cancelEdit();
-              }}
-              className="w-full px-2 py-1 text-sm border border-indigo-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white"
-            />
+            <input ref={inputRef} value={editTitle} onChange={(e) => setEditTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") saveEdit(); if (e.key === "Escape") cancelEdit(); }}
+              className="w-full px-2 py-1 text-sm border border-indigo-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white" />
             <div className="flex flex-wrap gap-2 items-center">
-              <select
-                value={editPriority}
-                onChange={(e) => setEditPriority(e.target.value as Todo["priority"])}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              >
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
+              <select value={editPriority} onChange={(e) => setEditPriority(e.target.value as Todo["priority"])} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
+                <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option>
               </select>
-              <select
-                value={editCategory}
-                onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              >
+              <select value={editCategory} onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
                 <option value="">No category</option>
-                {CATEGORIES.map((c) => (
-                  <option key={c} value={c}>{c}</option>
-                ))}
+                {CATEGORIES.map((c) => (<option key={c} value={c}>{c}</option>))}
               </select>
-              <input
-                type="date"
-                value={editDueDate}
-                onChange={(e) => setEditDueDate(e.target.value)}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              />
+              <input type="date" value={editDueDate} onChange={(e) => setEditDueDate(e.target.value)} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none" />
               <button onClick={saveEdit} className="text-xs px-3 py-1 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600">Save</button>
               <button onClick={cancelEdit} className="text-xs px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200">Cancel</button>
             </div>
@@ -144,58 +93,25 @@ export default function TodoItem({
         ) : (
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2 flex-wrap">
-              <span className={`text-sm font-medium truncate ${
-                todo.completed
-                  ? "line-through text-gray-400 dark:text-gray-500"
-                  : "text-gray-800 dark:text-gray-100"
-              }`}>
-                {todo.title}
-              </span>
-              <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${PRIORITY_COLORS[todo.priority]}`}>
-                {todo.priority}
-              </span>
-              {todo.category && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 border border-indigo-200 dark:bg-indigo-950 dark:text-indigo-300 dark:border-indigo-800">
-                  {todo.category}
-                </span>
-              )}
+              <span className={`text-sm font-medium truncate ${todo.completed ? "line-through text-gray-400 dark:text-gray-500" : "text-gray-800 dark:text-gray-100"}`}>{todo.title}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${PRIORITY_COLORS[todo.priority]}`}>{todo.priority}</span>
+              {todo.category && (<span className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 border border-indigo-200 dark:bg-indigo-950 dark:text-indigo-300 dark:border-indigo-800">{todo.category}</span>)}
             </div>
             {todo.dueDate && (
-              <span className={`text-xs ${
-                overdue
-                  ? "text-red-600 dark:text-red-400 font-semibold"
-                  : dueToday
-                  ? "text-orange-500 dark:text-orange-400 font-medium"
-                  : "text-gray-400 dark:text-gray-500"
-              }`}>
-                {overdue ? "⚠️ Overdue: " : dueToday ? "📅 Due today: " : "📅 Due: "}
-                {todo.dueDate}
+              <span className={`text-xs ${overdue ? "text-red-600 dark:text-red-400 font-semibold" : dueToday ? "text-orange-500 dark:text-orange-400 font-medium" : "text-gray-400 dark:text-gray-500"}`}>
+                {overdue ? "⚠️ Overdue: " : dueToday ? "📅 Due today: " : "📅 Due: "}{todo.dueDate}
               </span>
             )}
           </div>
         )}
       </div>
-
-      {/* Actions */}
       {!editing && (
         <div className="flex-shrink-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-          <button
-            onClick={() => setEditing(true)}
-            aria-label="Edit todo"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" />
-            </svg>
+          <button onClick={() => setEditing(true)} aria-label="Edit todo" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" /></svg>
           </button>
-          <button
-            onClick={() => onDelete(todo.id)}
-            aria-label="Delete todo"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
-            </svg>
+          <button onClick={() => onDelete(todo.id)} aria-label="Delete todo" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" /></svg>
           </button>
         </div>
       )}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,46 @@
+import { useEffect, useCallback } from "react";
+
+interface KeyboardShortcutActions {
+  onNewTodo: () => void;
+  onDelete: () => void;
+  onEdit: () => void;
+  onSearch: () => void;
+  onToggleComplete: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onEscape: () => void;
+}
+
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select" || (el as HTMLElement).isContentEditable;
+}
+
+export function useKeyboardShortcuts(actions: KeyboardShortcutActions) {
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        actions.onEscape();
+        return;
+      }
+      if (isInputFocused()) return;
+      switch (e.key) {
+        case "n": case "N": e.preventDefault(); actions.onNewTodo(); break;
+        case "d": case "D": e.preventDefault(); actions.onDelete(); break;
+        case "e": case "E": e.preventDefault(); actions.onEdit(); break;
+        case "/": e.preventDefault(); actions.onSearch(); break;
+        case " ": e.preventDefault(); actions.onToggleComplete(); break;
+        case "ArrowUp": case "k": e.preventDefault(); actions.onMoveUp(); break;
+        case "ArrowDown": case "j": e.preventDefault(); actions.onMoveDown(); break;
+      }
+    },
+    [actions]
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+}


### PR DESCRIPTION
## Summary
- Implements keyboard shortcuts for all common todo actions: **N** (new), **D** (delete), **E** (edit), **/** (search), **Space** (toggle complete)
- Adds arrow key / j/k navigation between todos with visual selection highlight
- Adds a search input to filter todos by title text
- Displays keyboard shortcut hints at the bottom of the app

## Changes
- **`src/hooks/useKeyboardShortcuts.ts`** (new): Custom hook that listens for global keyboard events, with smart input-focus detection to avoid conflicts when typing
- **`src/components/AddTodoForm.tsx`**: Converted to `forwardRef` with `useImperativeHandle` to expose `focusInput()` for the N shortcut
- **`src/components/TodoItem.tsx`**: Added `isSelected` prop (indigo ring highlight) and `autoEdit` prop (triggers edit mode from keyboard E shortcut)
- **`src/components/TodoApp.tsx`**: Added search state, selected todo index, editing state, all keyboard shortcut handlers, search input UI, and shortcut hints bar

## Keyboard Shortcuts
| Key | Action |
|-----|--------|
| N | Focus new todo input |
| / | Focus search input |
| ↑/↓ or j/k | Navigate between todos |
| Space | Toggle selected todo complete |
| E | Edit selected todo |
| D | Delete selected todo |
| Escape | Clear selection, search, and blur |

## Testing
- Open the app and press `/` — search input should focus
- Type a search query — todos filter by title in real time
- Press `Escape` — search clears, input blurs
- Press `↓` or `j` — first todo gets selected (indigo ring)
- Navigate with arrow keys — selection wraps around
- Press `Space` on a selected todo — toggles completion
- Press `E` on a selected todo — enters edit mode
- Press `D` on a selected todo — deletes it
- Press `N` — focuses the "What needs to be done?" input
- Verify shortcuts don't fire when typing in input fields

Closes #44