### PR TITLE
feat: add todo statistics dashboard

### DIFF
--- a/src/app/api/todos/stats/route.ts
+++ b/src/app/api/todos/stats/route.ts
@@ -1,0 +1,105 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const todos = await prisma.todo.findMany({
+    where: { userId: session.user.id },
+    select: {
+      completed: true,
+      createdAt: true,
+      updatedAt: true,
+      category: true,
+      priority: true,
+    },
+  });
+
+  const total = todos.length;
+  const completed = todos.filter((t) => t.completed).length;
+  const pending = total - completed;
+  const completionRate = total > 0 ? Math.round((completed / total) * 100) : 0;
+
+  // Completed todos grouped by date (using updatedAt as completion date)
+  const completedByDate = new Map<string, number>();
+  for (const todo of todos) {
+    if (todo.completed) {
+      const dateKey = todo.updatedAt.toISOString().split("T")[0];
+      completedByDate.set(dateKey, (completedByDate.get(dateKey) ?? 0) + 1);
+    }
+  }
+
+  // Streak: consecutive days (ending today or yesterday) with at least one completion
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  let streak = 0;
+  const checkDate = new Date(today);
+  const todayKey = checkDate.toISOString().split("T")[0];
+  if (!completedByDate.has(todayKey)) {
+    checkDate.setDate(checkDate.getDate() - 1);
+  }
+  while (true) {
+    const key = checkDate.toISOString().split("T")[0];
+    if (completedByDate.has(key)) {
+      streak++;
+      checkDate.setDate(checkDate.getDate() - 1);
+    } else {
+      break;
+    }
+  }
+
+  // Most productive days of the week
+  const dayTotals = [0, 0, 0, 0, 0, 0, 0];
+  for (const todo of todos) {
+    if (todo.completed) {
+      dayTotals[todo.updatedAt.getDay()]++;
+    }
+  }
+  const dayNames = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+  const productiveDays = dayNames
+    .map((name, i) => ({ day: name, count: dayTotals[i] }))
+    .sort((a, b) => b.count - a.count)
+    .filter((d) => d.count > 0);
+
+  // Category breakdown
+  const categoryMap = new Map<string, { total: number; completed: number }>();
+  for (const todo of todos) {
+    const cat = todo.category ?? "Uncategorized";
+    const entry = categoryMap.get(cat) ?? { total: 0, completed: 0 };
+    entry.total++;
+    if (todo.completed) entry.completed++;
+    categoryMap.set(cat, entry);
+  }
+  const categoryBreakdown = Array.from(categoryMap.entries()).map(([category, stats]) => ({
+    category,
+    ...stats,
+  }));
+
+  // Priority breakdown
+  const priorityMap = new Map<string, { total: number; completed: number }>();
+  for (const todo of todos) {
+    const entry = priorityMap.get(todo.priority) ?? { total: 0, completed: 0 };
+    entry.total++;
+    if (todo.completed) entry.completed++;
+    priorityMap.set(todo.priority, entry);
+  }
+  const priorityBreakdown = Array.from(priorityMap.entries()).map(([priority, stats]) => ({
+    priority,
+    ...stats,
+  }));
+
+  return NextResponse.json({
+    total,
+    completed,
+    pending,
+    completionRate,
+    streak,
+    productiveDays,
+    categoryBreakdown,
+    priorityBreakdown,
+  });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import ThemeToggle from "@/components/ThemeToggle";
+
+interface Stats {
+  total: number;
+  completed: number;
+  pending: number;
+  completionRate: number;
+  streak: number;
+  productiveDays: { day: string; count: number }[];
+  categoryBreakdown: { category: string; total: number; completed: number }[];
+  priorityBreakdown: { priority: string; total: number; completed: number }[];
+}
+
+const PRIORITY_ICONS: Record<string, string> = {
+  high: "🔴",
+  medium: "🟡",
+  low: "🟢",
+};
+
+const CATEGORY_ICONS: Record<string, string> = {
+  Work: "💼",
+  Personal: "👤",
+  Shopping: "🛒",
+  Health: "❤️",
+  Other: "📌",
+  Uncategorized: "📂",
+};
+
+export default function DashboardPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (status === "unauthenticated") {
+      router.push("/login");
+    }
+  }, [status, router]);
+
+  useEffect(() => {
+    if (status !== "authenticated") return;
+    fetch("/api/todos/stats")
+      .then((res) => res.json())
+      .then((data) => {
+        setStats(data);
+        setLoading(false);
+      })
+      .catch(() => setLoading(false));
+  }, [status]);
+
+  if (status === "loading" || loading) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 flex items-center justify-center">
+        <p className="text-gray-400">Loading statistics…</p>
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 flex items-center justify-center">
+        <p className="text-gray-400">Failed to load statistics.</p>
+      </div>
+    );
+  }
+
+  const maxDayCount = Math.max(...stats.productiveDays.map((d) => d.count), 1);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-indigo-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800 py-12 px-4">
+      <div className="max-w-2xl mx-auto">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-3xl font-extrabold text-indigo-600 dark:text-indigo-400 tracking-tight">
+              📊 Statistics
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              Your productivity at a glance
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <Link
+              href="/"
+              className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              ← Back to todos
+            </Link>
+          </div>
+        </div>
+
+        {/* Overview Cards */}
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-8">
+          <StatCard label="Total" value={stats.total} color="text-gray-700 dark:text-gray-200" />
+          <StatCard label="Completed" value={stats.completed} color="text-green-600 dark:text-green-400" />
+          <StatCard label="Pending" value={stats.pending} color="text-orange-600 dark:text-orange-400" />
+          <StatCard label="Completion" value={`${stats.completionRate}%`} color="text-indigo-600 dark:text-indigo-400" />
+        </div>
+
+        {/* Streak */}
+        <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm mb-6">
+          <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2">
+            Current Streak
+          </h2>
+          <div className="flex items-center gap-3">
+            <span className="text-4xl">🔥</span>
+            <div>
+              <p className="text-3xl font-bold text-gray-800 dark:text-gray-100">
+                {stats.streak} {stats.streak === 1 ? "day" : "days"}
+              </p>
+              <p className="text-xs text-gray-400 dark:text-gray-500">
+                Consecutive days completing todos
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Most Productive Days */}
+        {stats.productiveDays.length > 0 && (
+          <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm mb-6">
+            <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+              Most Productive Days
+            </h2>
+            <div className="space-y-2">
+              {stats.productiveDays.map(({ day, count }) => (
+                <div key={day} className="flex items-center gap-3">
+                  <span className="w-24 text-sm text-gray-600 dark:text-gray-300 shrink-0">
+                    {day}
+                  </span>
+                  <div className="flex-1 bg-gray-100 dark:bg-gray-700 rounded-full h-5 overflow-hidden">
+                    <div
+                      className="bg-indigo-500 dark:bg-indigo-400 h-full rounded-full transition-all"
+                      style={{ width: `${(count / maxDayCount) * 100}%` }}
+                    />
+                  </div>
+                  <span className="text-sm font-medium text-gray-600 dark:text-gray-300 w-8 text-right">
+                    {count}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Category Breakdown */}
+        {stats.categoryBreakdown.length > 0 && (
+          <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm mb-6">
+            <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+              By Category
+            </h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {stats.categoryBreakdown.map(({ category, total, completed }) => (
+                <div
+                  key={category}
+                  className="flex items-center justify-between bg-gray-50 dark:bg-gray-700/50 rounded-xl px-4 py-3"
+                >
+                  <span className="text-sm text-gray-700 dark:text-gray-200">
+                    {CATEGORY_ICONS[category] ?? "📂"} {category}
+                  </span>
+                  <span className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                    {completed}/{total}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Priority Breakdown */}
+        {stats.priorityBreakdown.length > 0 && (
+          <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 shadow-sm mb-6">
+            <h2 className="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-4">
+              By Priority
+            </h2>
+            <div className="grid grid-cols-3 gap-3">
+              {["high", "medium", "low"].map((p) => {
+                const entry = stats.priorityBreakdown.find((b) => b.priority === p);
+                if (!entry) return null;
+                return (
+                  <div
+                    key={p}
+                    className="text-center bg-gray-50 dark:bg-gray-700/50 rounded-xl px-4 py-3"
+                  >
+                    <p className="text-lg">{PRIORITY_ICONS[p]}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 capitalize mt-1">{p}</p>
+                    <p className="text-sm font-medium text-gray-700 dark:text-gray-200 mt-1">
+                      {entry.completed}/{entry.total}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value, color }: { label: string; value: string | number; color: string }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-2xl p-4 shadow-sm text-center">
+      <p className={`text-2xl font-bold ${color}`}>{value}</p>
+      <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">{label}</p>
+    </div>
+  );
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
+import Link from "next/link";
 import { useTodos } from "@/hooks/useTodos";
 import AddTodoForm from "./AddTodoForm";
 import TodoItem from "./TodoItem";
@@ -70,6 +71,7 @@ export default function TodoApp() {
               ✅ Todo App
             </h1>
             <div className="flex items-center gap-3">
+              <Link href="/dashboard" className="text-xs text-indigo-500 hover:text-indigo-700 dark:text-indigo-400 dark:hover:text-indigo-300 transition-colors">📊 Stats</Link>
               <ThemeToggle />
               {session?.user && (
                 <>


### PR DESCRIPTION
## Summary
- Added `/api/todos/stats` API endpoint that computes productivity metrics from the user's todos
- Created `/dashboard` page with visual statistics including completion rate, streak tracking, most productive days, and category/priority breakdowns
- Added navigation link ("📊 Stats") in the TodoApp header for easy access

## Changes
- **`src/app/api/todos/stats/route.ts`** — New API route that aggregates todo data: total/completed/pending counts, completion rate percentage, consecutive-day streak, most productive days of the week, and breakdowns by category and priority
- **`src/app/dashboard/page.tsx`** — New dashboard page with stat cards, streak display, bar chart for productive days, and category/priority grids. Includes dark mode support, auth protection, and responsive layout
- **`src/components/TodoApp.tsx`** — Added `Link` import and "📊 Stats" navigation link in the header

## Testing
- Navigate to `/dashboard` while logged in to view statistics
- Verify stats update after completing/adding todos
- Check dark mode renders correctly on the dashboard
- Verify unauthenticated users are redirected to login

Closes #40