### PR TITLE
feat: add drag-and-drop reordering for todos

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Todo {
   priority  String   @default("medium")
   category  String?
   dueDate   String?
+  sortOrder Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String?

--- a/src/app/api/todos/reorder/route.ts
+++ b/src/app/api/todos/reorder/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { orderedIds } = body as { orderedIds: string[] };
+
+  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+    return NextResponse.json({ error: "orderedIds is required" }, { status: 400 });
+  }
+
+  const updates = orderedIds.map((id, index) =>
+    prisma.todo.updateMany({
+      where: { id, userId: session.user.id },
+      data: { sortOrder: index },
+    })
+  );
+
+  await prisma.$transaction(updates);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   }
   const todos = await prisma.todo.findMany({
     where: { userId: session.user.id },
-    orderBy: { createdAt: "desc" },
+    orderBy: [{ sortOrder: "asc" }, { createdAt: "desc" }],
   });
   return NextResponse.json(todos);
 }

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useTodos } from "@/hooks/useTodos";
 import AddTodoForm from "./AddTodoForm";
@@ -22,12 +22,17 @@ const CATEGORY_ICONS: Record<Category, string> = {
 
 export default function TodoApp() {
   const { data: session } = useSession();
-  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } =
+  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, reorderTodos, clearCompleted } =
     useTodos();
   const [filter, setFilter] = useState<FilterType>("all");
   const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
 
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+  const isDefaultView = filter === "all" && categoryFilter === "all";
+
   const filteredTodos = useMemo(() => {
+    if (isDefaultView) return todos;
     return todos
       .filter((t) => {
         const statusMatch =
@@ -47,12 +52,21 @@ export default function TodoApp() {
           if (diff !== 0) return diff;
         }
         // Fall back to creation date (newest first)
-        return b.createdAt - a.createdAt;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });
-  }, [todos, filter, categoryFilter]);
+  }, [todos, filter, categoryFilter, isDefaultView]);
 
   const activeCount = todos.filter((t) => !t.completed).length;
   const completedCount = todos.filter((t) => t.completed).length;
+
+
+  const handleDragStart = useCallback((index: number) => { setDragIndex(index); }, []);
+  const handleDragOver = useCallback((e: React.DragEvent, index: number) => { e.preventDefault(); setDragOverIndex(index); }, []);
+  const handleDrop = useCallback((dropIndex: number) => {
+    if (dragIndex !== null && dragIndex !== dropIndex && isDefaultView) reorderTodos(dragIndex, dropIndex);
+    setDragIndex(null); setDragOverIndex(null);
+  }, [dragIndex, isDefaultView, reorderTodos]);
+  const handleDragEnd = useCallback(() => { setDragIndex(null); setDragOverIndex(null); }, []);
 
   const filters: { label: string; value: FilterType }[] = [
     { label: "All", value: "all" },
@@ -162,13 +176,17 @@ export default function TodoApp() {
           </div>
         ) : (
           <div className="flex flex-col gap-2">
-            {filteredTodos.map((todo: Todo) => (
-              <div key={todo.id} className="todo-item-enter">
+            {isDefaultView && filteredTodos.length > 1 && (
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Drag to reorder your todos</p>
+            )}
+            {filteredTodos.map((todo: Todo, index: number) => (
+              <div key={todo.id} className={`todo-item-enter transition-all ${dragIndex === index ? "opacity-50 scale-95" : ""} ${dragOverIndex === index && dragIndex !== index ? "border-t-2 border-indigo-400 pt-1" : ""}`} draggable={isDefaultView} onDragStart={() => handleDragStart(index)} onDragOver={(e) => handleDragOver(e, index)} onDrop={() => handleDrop(index)} onDragEnd={handleDragEnd}>
                 <TodoItem
                   todo={todo}
                   onToggle={toggleTodo}
                   onDelete={deleteTodo}
                   onEdit={editTodo}
+                  isDraggable={isDefaultView}
                 />
               </div>
             ))}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -22,6 +22,7 @@ interface TodoItemProps {
     category?: Todo["category"],
     dueDate?: string
   ) => void;
+  isDraggable?: boolean;
 }
 
 function isOverdue(dueDate?: string): boolean {
@@ -39,6 +40,7 @@ export default function TodoItem({
   onToggle,
   onDelete,
   onEdit,
+  isDraggable = false,
 }: TodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(todo.title);
@@ -80,6 +82,17 @@ export default function TodoItem({
         ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
         : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
     }`}>
+      {/* Drag Handle */}
+      {isDraggable && (
+        <div className="flex-shrink-0 mt-1 cursor-grab active:cursor-grabbing text-gray-300 hover:text-gray-500 dark:text-gray-600 dark:hover:text-gray-400">
+          <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24">
+            <circle cx="9" cy="6" r="1.5" /><circle cx="15" cy="6" r="1.5" />
+            <circle cx="9" cy="12" r="1.5" /><circle cx="15" cy="12" r="1.5" />
+            <circle cx="9" cy="18" r="1.5" /><circle cx="15" cy="18" r="1.5" />
+          </svg>
+        </div>
+      )}
+
       {/* Checkbox */}
       <button
         onClick={() => onToggle(todo.id)}

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -81,6 +81,7 @@ export function useTodos() {
         priority,
         category,
         dueDate,
+        sortOrder: 0,
         createdAt: new Date().toISOString(),
       };
       setTodos((prev) => [todo, ...prev]);
@@ -132,6 +133,23 @@ export function useTodos() {
     []
   );
 
+
+  const reorderTodos = useCallback(async (fromIndex: number, toIndex: number) => {
+    setTodos((prev) => {
+      const updated = [...prev];
+      const [moved] = updated.splice(fromIndex, 1);
+      updated.splice(toIndex, 0, moved);
+      const reordered = updated.map((t, i) => ({ ...t, sortOrder: i }));
+      const orderedIds = reordered.map((t) => t.id);
+      fetch("/api/todos/reorder", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orderedIds }),
+      }).catch(() => {});
+      return reordered;
+    });
+  }, []);
+
   const clearCompleted = useCallback(async () => {
     setTodos((prev) => {
       const toDelete = prev.filter((t) => t.completed);
@@ -149,6 +167,7 @@ export function useTodos() {
     toggleTodo,
     deleteTodo,
     editTodo,
+    reorderTodos,
     clearCompleted,
   };
 }

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -9,5 +9,6 @@ export interface Todo {
   priority: Priority;
   category?: Category;
   dueDate?: string; // ISO date string YYYY-MM-DD
+  sortOrder: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
Implements drag-and-drop functionality to manually reorder todos, with custom order saved per user.

## Changes
- **Prisma schema**: Added `sortOrder` field (Int, default 0) to the `Todo` model
- **API**: Updated `GET /api/todos` to order by `sortOrder` (ascending), then `createdAt` (descending). New todos get the lowest `sortOrder` to appear at top.
- **New endpoint**: `PUT /api/todos/reorder` accepts `{ orderedIds: string[] }` and updates `sortOrder` for each todo in a transaction
- **useTodos hook**: Added `reorderTodos(fromIndex, toIndex)` with optimistic local reordering and background API sync
- **TodoApp**: Added HTML5 drag-and-drop with visual feedback (opacity change on drag source, border indicator on drop target). Drag is only enabled in the default "All" view with no filters active.
- **TodoItem**: Added a 6-dot drag handle icon that appears when dragging is enabled

## Testing
1. Load the app and verify todos appear in the correct order
2. Drag a todo to a new position — it should snap into place immediately
3. Refresh the page — the new order should persist
4. Apply a filter (e.g., "Active" or a category) — drag handles should disappear and sorting reverts to date-based
5. Remove filters — custom order should be restored

Closes #36