### PR TITLE
feat: add todo attachments

### DIFF
--- a/prisma/migrations/20260318074000_add_archive_fields/migration.sql
+++ b/prisma/migrations/20260318074000_add_archive_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Todo" ADD COLUMN "archived" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "Todo" ADD COLUMN "archivedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,31 @@ model Todo {
   priority  String   @default("medium")
   category  String?
   dueDate   String?
+  sortOrder Int      @default(0)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String?
+  archived          Boolean   @default(false)
+  archivedAt        DateTime?
+}
+
+model Template {
+  id        String   @id @default(uuid())
+  name      String
+  title     String
+  priority  String   @default("medium")
+  category  String?
+  createdAt DateTime @default(now())
+  userId    String?
+}
+
+model NotificationPreference {
+  id              String   @id @default(uuid())
+  userId          String   @unique
+  enabled         Boolean  @default(true)
+  emailAddress    String
+  remindAt        String[] @default(["1_day_before"])
+  lastNotifiedAt  DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 }

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -2,6 +2,24 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
+function getNextDueDate(currentDueDate: string | null, pattern: string): string {
+  const base = currentDueDate ? new Date(currentDueDate) : new Date();
+  switch (pattern) {
+    case "daily":
+      base.setDate(base.getDate() + 1);
+      break;
+    case "weekly":
+      base.setDate(base.getDate() + 7);
+      break;
+    case "monthly":
+      base.setMonth(base.getMonth() + 1);
+      break;
+    default:
+      base.setDate(base.getDate() + 1);
+  }
+  return base.toISOString().split("T")[0];
+}
+
 export async function PUT(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -11,20 +29,46 @@ export async function PUT(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { id } = await params;
-  const { title, completed, priority, category, dueDate, archived } = await request.json();
-
-  const data: Record<string, unknown> = { title, completed, priority, category, dueDate };
-  if (typeof archived === "boolean") {
-    data.archived = archived;
-    data.archivedAt = archived ? new Date() : null;
-  }
+  const { title, completed, priority, category, dueDate, isRecurring, recurrencePattern, recurrenceEndDate } = await request.json();
 
   try {
+    const existing = await prisma.todo.findFirst({
+      where: { id, userId: session.user.id },
+    });
+
+    if (!existing) {
+      return NextResponse.json({ error: "Todo not found" }, { status: 404 });
+    }
+
     const todo = await prisma.todo.update({
       where: { id, userId: session.user.id },
-      data,
+      data: { title, completed, priority, category, dueDate, isRecurring, recurrencePattern, recurrenceEndDate },
     });
-    return NextResponse.json(todo);
+
+    let nextTodo = null;
+    if (completed && !existing.completed && existing.isRecurring && existing.recurrencePattern) {
+      const nextDueDate = getNextDueDate(existing.dueDate, existing.recurrencePattern);
+      const shouldCreate = !existing.recurrenceEndDate || nextDueDate <= existing.recurrenceEndDate;
+
+      if (shouldCreate) {
+        nextTodo = await prisma.todo.create({
+          data: {
+            title: existing.title,
+            completed: false,
+            priority: existing.priority,
+            category: existing.category,
+            dueDate: nextDueDate,
+            userId: existing.userId,
+            isRecurring: true,
+            recurrencePattern: existing.recurrencePattern,
+            recurrenceEndDate: existing.recurrenceEndDate,
+            parentTodoId: existing.parentTodoId ?? existing.id,
+          },
+        });
+      }
+    }
+
+    return NextResponse.json({ todo, nextTodo });
   } catch {
     return NextResponse.json({ error: "Todo not found" }, { status: 404 });
   }

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -11,12 +11,18 @@ export async function PUT(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { id } = await params;
-  const { title, completed, priority, category, dueDate } = await request.json();
+  const { title, completed, priority, category, dueDate, archived } = await request.json();
+
+  const data: Record<string, unknown> = { title, completed, priority, category, dueDate };
+  if (typeof archived === "boolean") {
+    data.archived = archived;
+    data.archivedAt = archived ? new Date() : null;
+  }
 
   try {
     const todo = await prisma.todo.update({
       where: { id, userId: session.user.id },
-      data: { title, completed, priority, category, dueDate },
+      data,
     });
     return NextResponse.json(todo);
   } catch {

--- a/src/app/api/todos/reorder/route.ts
+++ b/src/app/api/todos/reorder/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { orderedIds } = body as { orderedIds: string[] };
+
+  if (!Array.isArray(orderedIds) || orderedIds.length === 0) {
+    return NextResponse.json({ error: "orderedIds is required" }, { status: 400 });
+  }
+
+  const updates = orderedIds.map((id, index) =>
+    prisma.todo.updateMany({
+      where: { id, userId: session.user.id },
+      data: { sortOrder: index },
+    })
+  );
+
+  await prisma.$transaction(updates);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -21,10 +21,14 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json();
-  const { title, priority, category, dueDate } = body;
+  const { title, priority, category, dueDate, isRecurring, recurrencePattern, recurrenceEndDate } = body;
 
   if (!title || typeof title !== "string" || !title.trim()) {
     return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  if (isRecurring && !recurrencePattern) {
+    return NextResponse.json({ error: "recurrencePattern is required for recurring todos" }, { status: 400 });
   }
 
   const todo = await prisma.todo.create({
@@ -35,6 +39,9 @@ export async function POST(request: NextRequest) {
       category: category ?? null,
       dueDate: dueDate ?? null,
       userId: session.user.id,
+      isRecurring: isRecurring ?? false,
+      recurrencePattern: isRecurring ? recurrencePattern : null,
+      recurrenceEndDate: isRecurring ? (recurrenceEndDate ?? null) : null,
     },
   });
 

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useTodos } from "@/hooks/useTodos";
+import { useTemplates } from "@/hooks/useTemplates";
 import AddTodoForm from "./AddTodoForm";
 import TodoItem from "./TodoItem";
+import TemplateLibrary from "./TemplateLibrary";
 import ThemeToggle from "./ThemeToggle";
-import { Todo, Category } from "@/types/todo";
+import ExportModal from "./ExportModal";
+import { Todo, Template, Category } from "@/types/todo";
 
 type FilterType = "all" | "active" | "completed";
 
@@ -22,10 +25,34 @@ const CATEGORY_ICONS: Record<Category, string> = {
 
 export default function TodoApp() {
   const { data: session } = useSession();
-  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } =
-    useTodos();
-  const [filter, setFilter] = useState<FilterType>("all");
+  const {
+    todos,
+    archivedTodos,
+    hydrated,
+    addTodo,
+    toggleTodo,
+    deleteTodo,
+    editTodo,
+    archiveTodo,
+    restoreTodo,
+    deleteArchivedTodo,
+    loadArchivedTodos,
+    clearCompleted,
+  } = useTodos();
+  const { templates, addTemplate, deleteTemplate } = useTemplates();
+
+  const handleUseTemplate = (template: Template) => {
+    addTodo(template.title, template.priority, template.category);
+  };  const [filter, setFilter] = useState<FilterType>("all");
   const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
+  const [showExport, setShowExport] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  useEffect(() => {
+    if (showArchived) {
+      loadArchivedTodos();
+    }
+  }, [showArchived, loadArchivedTodos]);
 
   const filteredTodos = useMemo(() => {
     return todos
@@ -38,16 +65,13 @@ export default function TodoApp() {
         return statusMatch && categoryMatch;
       })
       .sort((a, b) => {
-        // Items with due dates come before items without
         if (a.dueDate && !b.dueDate) return -1;
         if (!a.dueDate && b.dueDate) return 1;
-        // Both have due dates: sort soonest first
         if (a.dueDate && b.dueDate) {
           const diff = a.dueDate.localeCompare(b.dueDate);
           if (diff !== 0) return diff;
         }
-        // Fall back to creation date (newest first)
-        return b.createdAt - a.createdAt;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });
   }, [todos, filter, categoryFilter]);
 
@@ -70,7 +94,7 @@ export default function TodoApp() {
               ✅ Todo App
             </h1>
             <div className="flex items-center gap-3">
-              <ThemeToggle />
+              <button onClick={() => setShowExport(true)} className="px-3 py-1.5 text-xs font-medium text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700 rounded-lg transition-colors">Export</button>              <ThemeToggle />
               {session?.user && (
                 <>
                   <span className="text-sm text-gray-600 dark:text-gray-400">
@@ -91,16 +115,26 @@ export default function TodoApp() {
           </p>
         </div>
 
-        {/* Add Form */}
-        <div className="mb-6">
-          <AddTodoForm onAdd={addTodo} />
-        </div>
+        {/* Add Form - hidden in archive view */}
+        {!showArchived && (
+          <div className="mb-6">
+            <AddTodoForm onAdd={addTodo} />
+          <div className="mt-3">
+            <TemplateLibrary
+              templates={templates}
+              onUseTemplate={handleUseTemplate}
+              onAddTemplate={addTemplate}
+              onDeleteTemplate={deleteTemplate}
+            />
+          </div>
+          </div>
+        )}
 
         {/* Filter Tabs + Stats */}
         <div className="flex flex-col gap-2 mb-4">
           <div className="flex items-center justify-between">
             <div className="flex gap-1 bg-gray-100 dark:bg-gray-800 p-1 rounded-xl">
-              {filters.map(({ label, value }) => (
+              {!showArchived && filters.map(({ label, value }) => (
                 <button
                   key={value}
                   onClick={() => setFilter(value)}
@@ -113,80 +147,122 @@ export default function TodoApp() {
                   {label}
                 </button>
               ))}
+              <button
+                onClick={() => setShowArchived(!showArchived)}
+                className={`px-4 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  showArchived
+                    ? "bg-white dark:bg-gray-700 text-indigo-600 dark:text-indigo-400 shadow-sm"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                }`}
+              >
+                Archived{archivedTodos.length > 0 ? ` (${archivedTodos.length})` : ""}
+              </button>
             </div>
-            <span className="text-xs text-gray-400 dark:text-gray-500">
-              {activeCount} left
-            </span>
+            {!showArchived && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {activeCount} left
+              </span>
+            )}
           </div>
 
-          {/* Category Filter */}
-          <div className="flex flex-wrap gap-1">
-            <button
-              onClick={() => setCategoryFilter("all")}
-              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                categoryFilter === "all"
-                  ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
-                  : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
-              }`}
-            >
-              📂 All
-            </button>
-            {CATEGORIES.map((cat) => (
+          {/* Category Filter - hidden in archive view */}
+          {!showArchived && (
+            <div className="flex flex-wrap gap-1">
               <button
-                key={cat}
-                onClick={() => setCategoryFilter(cat)}
+                onClick={() => setCategoryFilter("all")}
                 className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
-                  categoryFilter === cat
+                  categoryFilter === "all"
                     ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
                     : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
                 }`}
               >
-                {CATEGORY_ICONS[cat]} {cat}
+                📂 All
               </button>
-            ))}
-          </div>
+              {CATEGORIES.map((cat) => (
+                <button
+                  key={cat}
+                  onClick={() => setCategoryFilter(cat)}
+                  className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                    categoryFilter === cat
+                      ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-300"
+                      : "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700"
+                  }`}
+                >
+                  {CATEGORY_ICONS[cat]} {cat}
+                </button>
+              ))}
+            </div>
+          )}
         </div>
 
-        {/* Todo List */}
-        {!hydrated ? (
-          <div className="text-center py-16 text-gray-400">Loading…</div>
-        ) : filteredTodos.length === 0 ? (
-          <div className="text-center py-16">
-            <p className="text-gray-400 text-sm">
-              {filter === "completed"
-                ? "No completed todos yet."
-                : filter === "active"
-                ? "Nothing left to do!"
-                : "Add your first todo above!"}
-            </p>
-          </div>
+        {/* Archived View */}
+        {showArchived ? (
+          archivedTodos.length === 0 ? (
+            <div className="text-center py-16">
+              <p className="text-gray-400 text-sm">No archived todos.</p>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {archivedTodos.map((todo: Todo) => (
+                <div key={todo.id} className="todo-item-enter">
+                  <TodoItem
+                    todo={todo}
+                    onToggle={toggleTodo}
+                    onDelete={deleteArchivedTodo}
+                    onEdit={editTodo}
+                    onRestore={restoreTodo}
+                    isArchived
+                  />
+                </div>
+              ))}
+            </div>
+          )
         ) : (
-          <div className="flex flex-col gap-2">
-            {filteredTodos.map((todo: Todo) => (
-              <div key={todo.id} className="todo-item-enter">
-                <TodoItem
-                  todo={todo}
-                  onToggle={toggleTodo}
-                  onDelete={deleteTodo}
-                  onEdit={editTodo}
-                />
+          <>
+            {/* Active Todo List */}
+            {!hydrated ? (
+              <div className="text-center py-16 text-gray-400">Loading…</div>
+            ) : filteredTodos.length === 0 ? (
+              <div className="text-center py-16">
+                <p className="text-gray-400 text-sm">
+                  {filter === "completed"
+                    ? "No completed todos yet."
+                    : filter === "active"
+                    ? "Nothing left to do!"
+                    : "Add your first todo above!"}
+                </p>
               </div>
-            ))}
-          </div>
-        )}
+            ) : (
+              <div className="flex flex-col gap-2">
+                {filteredTodos.map((todo: Todo) => (
+                  <div key={todo.id} className="todo-item-enter">
+                    <TodoItem
+                      todo={todo}
+                      onToggle={toggleTodo}
+                      onDelete={deleteTodo}
+                      onEdit={editTodo}
+                      onArchive={archiveTodo}
+                    />
+                  </div>
+                ))}
+              </div>
+            )}
 
-        {/* Footer actions */}
-        {completedCount > 0 && (
-          <div className="mt-4 flex justify-end">
-            <button
-              onClick={clearCompleted}
-              className="text-xs text-gray-400 hover:text-red-500 transition-colors"
-            >
-              Clear completed ({completedCount})
-            </button>
-          </div>
+            {/* Footer actions */}
+            {completedCount > 0 && (
+              <div className="mt-4 flex justify-end">
+                <button
+                  onClick={clearCompleted}
+                  className="text-xs text-gray-400 hover:text-amber-600 transition-colors"
+                >
+                  Archive completed ({completedCount})
+                </button>
+              </div>
+            )}
+          </>
         )}
       </div>
+      <ExportModal open={showExport} onClose={() => setShowExport(false)} />
     </div>
   );
 }

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -9,6 +9,7 @@ import TodoItem from "./TodoItem";
 import TemplateLibrary from "./TemplateLibrary";
 import ThemeToggle from "./ThemeToggle";
 import ExportModal from "./ExportModal";
+import NotificationSettings from "./NotificationSettings";
 import { Todo, Template, Category } from "@/types/todo";
 
 type FilterType = "all" | "active" | "completed";

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -15,13 +15,10 @@ interface TodoItemProps {
   todo: Todo;
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
-  onEdit: (
-    id: string,
-    title: string,
-    priority: Todo["priority"],
-    category?: Todo["category"],
-    dueDate?: string
-  ) => void;
+  onEdit: (id: string, title: string, priority: Todo["priority"], category?: Todo["category"], dueDate?: string) => void;
+  onArchive?: (id: string) => void;
+  onRestore?: (id: string) => void;
+  isArchived?: boolean;
 }
 
 function isOverdue(dueDate?: string): boolean {
@@ -34,12 +31,7 @@ function isDueToday(dueDate?: string): boolean {
   return dueDate === new Date().toISOString().split("T")[0];
 }
 
-export default function TodoItem({
-  todo,
-  onToggle,
-  onDelete,
-  onEdit,
-}: TodoItemProps) {
+export default function TodoItem({ todo, onToggle, onDelete, onEdit, onArchive, onRestore, isArchived }: TodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(todo.title);
   const [editPriority, setEditPriority] = useState<Todo["priority"]>(todo.priority);
@@ -76,30 +68,34 @@ export default function TodoItem({
 
   return (
     <li className={`flex items-start gap-3 p-4 rounded-xl shadow-sm border group transition-all hover:shadow-md ${
-      overdue
+      isArchived
+        ? "bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700 opacity-75"
+        : overdue
         ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
         : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
     }`}>
       {/* Checkbox */}
-      <button
-        onClick={() => onToggle(todo.id)}
-        aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
-        className={`flex-shrink-0 mt-0.5 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
-          todo.completed
-            ? "bg-indigo-500 border-indigo-500 text-white"
-            : "border-gray-300 hover:border-indigo-400"
-        }`}
-      >
-        {todo.completed && (
-          <svg className="w-3 h-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-          </svg>
-        )}
-      </button>
+      {!isArchived && (
+        <button
+          onClick={() => onToggle(todo.id)}
+          aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
+          className={`flex-shrink-0 mt-0.5 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
+            todo.completed
+              ? "bg-indigo-500 border-indigo-500 text-white"
+              : "border-gray-300 hover:border-indigo-400"
+          }`}
+        >
+          {todo.completed && (
+            <svg className="w-3 h-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+            </svg>
+          )}
+        </button>
+      )}
 
       {/* Content */}
       <div className="flex-1 min-w-0">
-        {editing ? (
+        {editing && !isArchived ? (
           <div className="flex flex-col gap-2">
             <input
               ref={inputRef}
@@ -112,31 +108,16 @@ export default function TodoItem({
               className="w-full px-2 py-1 text-sm border border-indigo-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white"
             />
             <div className="flex flex-wrap gap-2 items-center">
-              <select
-                value={editPriority}
-                onChange={(e) => setEditPriority(e.target.value as Todo["priority"])}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              >
+              <select value={editPriority} onChange={(e) => setEditPriority(e.target.value as Todo["priority"])} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
                 <option value="low">Low</option>
                 <option value="medium">Medium</option>
                 <option value="high">High</option>
               </select>
-              <select
-                value={editCategory}
-                onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              >
+              <select value={editCategory} onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
                 <option value="">No category</option>
-                {CATEGORIES.map((c) => (
-                  <option key={c} value={c}>{c}</option>
-                ))}
+                {CATEGORIES.map((c) => (<option key={c} value={c}>{c}</option>))}
               </select>
-              <input
-                type="date"
-                value={editDueDate}
-                onChange={(e) => setEditDueDate(e.target.value)}
-                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none"
-              />
+              <input type="date" value={editDueDate} onChange={(e) => setEditDueDate(e.target.value)} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none" />
               <button onClick={saveEdit} className="text-xs px-3 py-1 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600">Save</button>
               <button onClick={cancelEdit} className="text-xs px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200">Cancel</button>
             </div>
@@ -144,8 +125,13 @@ export default function TodoItem({
         ) : (
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2 flex-wrap">
+              {isArchived && (
+                <span className="text-xs px-2 py-0.5 rounded-full bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 font-medium">
+                  Archived
+                </span>
+              )}
               <span className={`text-sm font-medium truncate ${
-                todo.completed
+                todo.completed || isArchived
                   ? "line-through text-gray-400 dark:text-gray-500"
                   : "text-gray-800 dark:text-gray-100"
               }`}>
@@ -168,8 +154,13 @@ export default function TodoItem({
                   ? "text-orange-500 dark:text-orange-400 font-medium"
                   : "text-gray-400 dark:text-gray-500"
               }`}>
-                {overdue ? "⚠️ Overdue: " : dueToday ? "📅 Due today: " : "📅 Due: "}
+                {overdue ? "\u26a0\ufe0f Overdue: " : dueToday ? "\U0001f4c5 Due today: " : "\U0001f4c5 Due: "}
                 {todo.dueDate}
+              </span>
+            )}
+            {isArchived && todo.archivedAt && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                Archived on {new Date(todo.archivedAt).toLocaleDateString()}
               </span>
             )}
           </div>
@@ -179,24 +170,42 @@ export default function TodoItem({
       {/* Actions */}
       {!editing && (
         <div className="flex-shrink-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-          <button
-            onClick={() => setEditing(true)}
-            aria-label="Edit todo"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" />
-            </svg>
-          </button>
-          <button
-            onClick={() => onDelete(todo.id)}
-            aria-label="Delete todo"
-            className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors"
-          >
-            <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
-            </svg>
-          </button>
+          {isArchived ? (
+            <>
+              {onRestore && (
+                <button onClick={() => onRestore(todo.id)} aria-label="Restore todo" className="p-1.5 rounded-lg text-gray-400 hover:text-green-500 hover:bg-green-50 dark:hover:bg-gray-700 transition-colors">
+                  <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
+                  </svg>
+                </button>
+              )}
+              <button onClick={() => onDelete(todo.id)} aria-label="Delete permanently" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
+                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
+                </svg>
+              </button>
+            </>
+          ) : (
+            <>
+              <button onClick={() => setEditing(true)} aria-label="Edit todo" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" />
+                </svg>
+              </button>
+              {onArchive && (
+                <button onClick={() => onArchive(todo.id)} aria-label="Archive todo" className="p-1.5 rounded-lg text-gray-400 hover:text-amber-500 hover:bg-amber-50 dark:hover:bg-gray-700 transition-colors">
+                  <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                  </svg>
+                </button>
+              )}
+              <button onClick={() => onDelete(todo.id)} aria-label="Delete todo" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
+                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
+                </svg>
+              </button>
+            </>
+          )}
         </div>
       )}
     </li>

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import { Todo, Category } from "@/types/todo";
+import { Todo, Attachment, AttachmentType, Category } from "@/types/todo";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 const PRIORITY_COLORS = {
   low: "bg-green-100 text-green-700 border-green-300",
@@ -9,16 +11,29 @@ const PRIORITY_COLORS = {
   high: "bg-red-100 text-red-700 border-red-300",
 };
 
+const PRIORITY_ICONS = { low: "🟢", medium: "🟡", high: "🔴" };
+const PRIORITY_BORDER = { low: "", medium: "", high: "border-l-4 border-l-red-400 dark:border-l-red-500" };
 const CATEGORIES: Category[] = ["Work", "Personal", "Shopping", "Health", "Other"];
+const ATTACHMENT_ICONS: Record<AttachmentType, string> = { image: "🖼️", file: "📄", link: "🔗" };
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getAttachmentType(mimeType: string): AttachmentType {
+  if (mimeType.startsWith("image/")) return "image";
+  return "file";
+}
 
 interface TodoItemProps {
   todo: Todo;
   onToggle: (id: string) => void;
   onDelete: (id: string) => void;
   onEdit: (id: string, title: string, priority: Todo["priority"], category?: Todo["category"], dueDate?: string) => void;
-  onArchive?: (id: string) => void;
-  onRestore?: (id: string) => void;
-  isArchived?: boolean;
+  onAddAttachment: (todoId: string, attachment: Attachment) => void;
+  onRemoveAttachment: (todoId: string, attachmentId: string) => void;
 }
 
 function isOverdue(dueDate?: string): boolean {
@@ -31,93 +46,90 @@ function isDueToday(dueDate?: string): boolean {
   return dueDate === new Date().toISOString().split("T")[0];
 }
 
-export default function TodoItem({ todo, onToggle, onDelete, onEdit, onArchive, onRestore, isArchived }: TodoItemProps) {
+export default function TodoItem({ todo, onToggle, onDelete, onEdit, onAddAttachment, onRemoveAttachment }: TodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(todo.title);
   const [editPriority, setEditPriority] = useState<Todo["priority"]>(todo.priority);
   const [editCategory, setEditCategory] = useState<Todo["category"] | "">(todo.category ?? "");
   const [editDueDate, setEditDueDate] = useState(todo.dueDate ?? "");
+  const [showLinkInput, setShowLinkInput] = useState(false);
+  const [linkUrl, setLinkUrl] = useState("");
+  const [linkName, setLinkName] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files) return;
+    Array.from(files).forEach((file) => {
+      if (file.size > MAX_FILE_SIZE) { alert(`File "${file.name}" exceeds 5MB limit.`); return; }
+      const reader = new FileReader();
+      reader.onload = () => {
+        onAddAttachment(todo.id, {
+          id: crypto.randomUUID(), name: file.name, type: getAttachmentType(file.type),
+          url: reader.result as string, mimeType: file.type, size: file.size,
+        });
+      };
+      reader.readAsDataURL(file);
+    });
+    e.target.value = "";
+  };
+
+  const handleAddLink = () => {
+    if (!linkUrl.trim()) return;
+    onAddAttachment(todo.id, { id: crypto.randomUUID(), name: linkName.trim() || linkUrl.trim(), type: "link", url: linkUrl.trim() });
+    setLinkUrl(""); setLinkName(""); setShowLinkInput(false);
+  };
 
   const saveEdit = () => {
     if (editTitle.trim()) {
       onEdit(todo.id, editTitle, editPriority, editCategory || undefined, editDueDate || undefined);
     } else {
-      setEditTitle(todo.title);
-      setEditPriority(todo.priority);
-      setEditCategory(todo.category ?? "");
-      setEditDueDate(todo.dueDate ?? "");
+      setEditTitle(todo.title); setEditPriority(todo.priority); setEditCategory(todo.category ?? ""); setEditDueDate(todo.dueDate ?? "");
     }
     setEditing(false);
   };
 
   const cancelEdit = () => {
-    setEditTitle(todo.title);
-    setEditPriority(todo.priority);
-    setEditCategory(todo.category ?? "");
-    setEditDueDate(todo.dueDate ?? "");
+    setEditTitle(todo.title); setEditPriority(todo.priority); setEditCategory(todo.category ?? ""); setEditDueDate(todo.dueDate ?? "");
     setEditing(false);
   };
 
   const overdue = !todo.completed && isOverdue(todo.dueDate);
   const dueToday = !todo.completed && isDueToday(todo.dueDate);
+  const attachments = todo.attachments ?? [];
 
   return (
     <li className={`flex items-start gap-3 p-4 rounded-xl shadow-sm border group transition-all hover:shadow-md ${
-      isArchived
-        ? "bg-gray-50 dark:bg-gray-900 border-gray-200 dark:border-gray-700 opacity-75"
-        : overdue
-        ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
-        : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
-    }`}>
-      {/* Checkbox */}
-      {!isArchived && (
-        <button
-          onClick={() => onToggle(todo.id)}
-          aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
-          className={`flex-shrink-0 mt-0.5 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
-            todo.completed
-              ? "bg-indigo-500 border-indigo-500 text-white"
-              : "border-gray-300 hover:border-indigo-400"
-          }`}
-        >
-          {todo.completed && (
-            <svg className="w-3 h-3" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
-            </svg>
-          )}
-        </button>
-      )}
+      overdue ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800" : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
+    } ${PRIORITY_BORDER[todo.priority]}`}>
+      <button onClick={() => onToggle(todo.id)} aria-label={todo.completed ? "Mark incomplete" : "Mark complete"}
+        className={`flex-shrink-0 mt-0.5 w-6 h-6 rounded-full border-2 flex items-center justify-center transition-colors ${
+          todo.completed ? "bg-indigo-500 border-indigo-500 text-white" : "border-gray-300 hover:border-indigo-400"
+        }`}>
+        {todo.completed && (<svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={3}><path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" /></svg>)}
+      </button>
 
-      {/* Content */}
       <div className="flex-1 min-w-0">
-        {editing && !isArchived ? (
+        {editing ? (
           <div className="flex flex-col gap-2">
-            <input
-              ref={inputRef}
-              value={editTitle}
-              onChange={(e) => setEditTitle(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") saveEdit();
-                if (e.key === "Escape") cancelEdit();
-              }}
-              className="w-full px-2 py-1 text-sm border border-indigo-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white"
-            />
+            <input ref={inputRef} value={editTitle} onChange={(e) => setEditTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === "Enter") saveEdit(); if (e.key === "Escape") cancelEdit(); }}
+              className="w-full px-2 py-1 text-sm border border-indigo-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white" />
             <div className="flex flex-wrap gap-2 items-center">
-              <select value={editPriority} onChange={(e) => setEditPriority(e.target.value as Todo["priority"])} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
-                <option value="low">Low</option>
-                <option value="medium">Medium</option>
-                <option value="high">High</option>
+              <select value={editPriority} onChange={(e) => setEditPriority(e.target.value as Todo["priority"])}
+                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
+                <option value="low">Low</option><option value="medium">Medium</option><option value="high">High</option>
               </select>
-              <select value={editCategory} onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
+              <select value={editCategory} onChange={(e) => setEditCategory(e.target.value as Todo["category"] | "")}
+                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none">
                 <option value="">No category</option>
                 {CATEGORIES.map((c) => (<option key={c} value={c}>{c}</option>))}
               </select>
-              <input type="date" value={editDueDate} onChange={(e) => setEditDueDate(e.target.value)} className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none" />
+              <input type="date" value={editDueDate} onChange={(e) => setEditDueDate(e.target.value)}
+                className="text-xs px-2 py-1 border border-gray-300 rounded-lg dark:bg-gray-700 dark:text-white focus:outline-none" />
               <button onClick={saveEdit} className="text-xs px-3 py-1 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600">Save</button>
               <button onClick={cancelEdit} className="text-xs px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200">Cancel</button>
             </div>
@@ -125,87 +137,75 @@ export default function TodoItem({ todo, onToggle, onDelete, onEdit, onArchive, 
         ) : (
           <div className="flex flex-col gap-1">
             <div className="flex items-center gap-2 flex-wrap">
-              {isArchived && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-400 font-medium">
-                  Archived
-                </span>
-              )}
-              <span className={`text-sm font-medium truncate ${
-                todo.completed || isArchived
-                  ? "line-through text-gray-400 dark:text-gray-500"
-                  : "text-gray-800 dark:text-gray-100"
-              }`}>
-                {todo.title}
-              </span>
-              <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${PRIORITY_COLORS[todo.priority]}`}>
-                {todo.priority}
-              </span>
-              {todo.category && (
-                <span className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 border border-indigo-200 dark:bg-indigo-950 dark:text-indigo-300 dark:border-indigo-800">
-                  {todo.category}
-                </span>
-              )}
+              <span className={`text-sm font-medium truncate ${todo.completed ? "line-through text-gray-400 dark:text-gray-500" : "text-gray-800 dark:text-gray-100"}`}>{todo.title}</span>
+              <span className={`text-xs px-2 py-0.5 rounded-full border font-medium ${PRIORITY_COLORS[todo.priority]}`}>{PRIORITY_ICONS[todo.priority]} {todo.priority}</span>
+              {todo.category && (<span className="text-xs px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-600 border border-indigo-200 dark:bg-indigo-950 dark:text-indigo-300 dark:border-indigo-800">{todo.category}</span>)}
             </div>
             {todo.dueDate && (
-              <span className={`text-xs ${
-                overdue
-                  ? "text-red-600 dark:text-red-400 font-semibold"
-                  : dueToday
-                  ? "text-orange-500 dark:text-orange-400 font-medium"
-                  : "text-gray-400 dark:text-gray-500"
-              }`}>
-                {overdue ? "\u26a0\ufe0f Overdue: " : dueToday ? "\U0001f4c5 Due today: " : "\U0001f4c5 Due: "}
-                {todo.dueDate}
+              <span className={`text-xs ${overdue ? "text-red-600 dark:text-red-400 font-semibold" : dueToday ? "text-orange-500 dark:text-orange-400 font-medium" : "text-gray-400 dark:text-gray-500"}`}>
+                {overdue ? "⚠️ Overdue: " : dueToday ? "📅 Due today: " : "📅 Due: "}{todo.dueDate}
               </span>
             )}
-            {isArchived && todo.archivedAt && (
-              <span className="text-xs text-gray-400 dark:text-gray-500">
-                Archived on {new Date(todo.archivedAt).toLocaleDateString()}
-              </span>
+            {attachments.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-1.5">
+                {attachments.map((att) => (
+                  <div key={att.id} className="group/att flex items-center gap-1.5 px-2 py-1 bg-gray-50 dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg text-xs">
+                    {att.type === "image" ? (
+                      <a href={att.url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 min-w-0">
+                        <img src={att.url} alt={att.name} className="w-6 h-6 rounded object-cover flex-shrink-0" />
+                        <span className="truncate max-w-[120px] text-gray-600 dark:text-gray-300">{att.name}</span>
+                      </a>
+                    ) : att.type === "link" ? (
+                      <a href={att.url} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1 min-w-0 text-indigo-600 dark:text-indigo-400 hover:underline">
+                        <span>{ATTACHMENT_ICONS.link}</span><span className="truncate max-w-[120px]">{att.name}</span>
+                      </a>
+                    ) : (
+                      <a href={att.url} download={att.name} className="flex items-center gap-1 min-w-0 text-gray-600 dark:text-gray-300 hover:text-indigo-500">
+                        <span>{ATTACHMENT_ICONS.file}</span><span className="truncate max-w-[120px]">{att.name}</span>
+                      </a>
+                    )}
+                    {att.size && (<span className="text-gray-400 dark:text-gray-500 flex-shrink-0">({formatFileSize(att.size)})</span>)}
+                    <button onClick={() => onRemoveAttachment(todo.id, att.id)} className="opacity-0 group-hover/att:opacity-100 text-gray-400 hover:text-red-500 transition-all flex-shrink-0" aria-label={`Remove ${att.name}`}>
+                      <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+            {showLinkInput && (
+              <div className="flex flex-col gap-1.5 mt-1.5 p-2 bg-gray-50 dark:bg-gray-700 rounded-lg border border-gray-200 dark:border-gray-600">
+                <input type="url" value={linkUrl} onChange={(e) => setLinkUrl(e.target.value)} placeholder="https://example.com"
+                  className="w-full text-xs px-2 py-1 border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                  onKeyDown={(e) => { if (e.key === "Enter") handleAddLink(); if (e.key === "Escape") setShowLinkInput(false); }} autoFocus />
+                <input type="text" value={linkName} onChange={(e) => setLinkName(e.target.value)} placeholder="Link name (optional)"
+                  className="w-full text-xs px-2 py-1 border border-gray-300 dark:border-gray-500 rounded-lg bg-white dark:bg-gray-800 dark:text-white focus:outline-none focus:ring-1 focus:ring-indigo-400"
+                  onKeyDown={(e) => { if (e.key === "Enter") handleAddLink(); if (e.key === "Escape") setShowLinkInput(false); }} />
+                <div className="flex gap-1.5">
+                  <button onClick={handleAddLink} disabled={!linkUrl.trim()} className="text-xs px-2 py-0.5 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 disabled:opacity-40">Add</button>
+                  <button onClick={() => { setShowLinkInput(false); setLinkUrl(""); setLinkName(""); }} className="text-xs px-2 py-0.5 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200">Cancel</button>
+                </div>
+              </div>
             )}
           </div>
         )}
       </div>
 
-      {/* Actions */}
+      <input ref={fileInputRef} type="file" multiple accept="image/*,.pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,.zip" onChange={handleFileSelect} className="hidden" />
+
       {!editing && (
         <div className="flex-shrink-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-          {isArchived ? (
-            <>
-              {onRestore && (
-                <button onClick={() => onRestore(todo.id)} aria-label="Restore todo" className="p-1.5 rounded-lg text-gray-400 hover:text-green-500 hover:bg-green-50 dark:hover:bg-gray-700 transition-colors">
-                  <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M3 10h10a5 5 0 015 5v2M3 10l4-4M3 10l4 4" />
-                  </svg>
-                </button>
-              )}
-              <button onClick={() => onDelete(todo.id)} aria-label="Delete permanently" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
-                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
-                </svg>
-              </button>
-            </>
-          ) : (
-            <>
-              <button onClick={() => setEditing(true)} aria-label="Edit todo" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
-                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" />
-                </svg>
-              </button>
-              {onArchive && (
-                <button onClick={() => onArchive(todo.id)} aria-label="Archive todo" className="p-1.5 rounded-lg text-gray-400 hover:text-amber-500 hover:bg-amber-50 dark:hover:bg-gray-700 transition-colors">
-                  <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
-                  </svg>
-                </button>
-              )}
-              <button onClick={() => onDelete(todo.id)} aria-label="Delete todo" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
-                <svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" />
-                </svg>
-              </button>
-            </>
-          )}
+          <button onClick={() => fileInputRef.current?.click()} aria-label="Attach file" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13" /></svg>
+          </button>
+          <button onClick={() => setShowLinkInput(!showLinkInput)} aria-label="Attach link" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>
+          </button>
+          <button onClick={() => setEditing(true)} aria-label="Edit todo" className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15.232 5.232l3.536 3.536M9 11l6.536-6.536a2 2 0 012.828 0l.172.172a2 2 0 010 2.828L12 14H9v-3z" /></svg>
+          </button>
+          <button onClick={() => onDelete(todo.id)} aria-label="Delete todo" className="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-gray-700 transition-colors">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6M1 7h22M8 7V4a1 1 0 011-1h6a1 1 0 011 1v3" /></svg>
+          </button>
         </div>
       )}
     </li>

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -1,20 +1,19 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { Todo } from "@/types/todo";
+import { Todo, RecurrencePattern } from "@/types/todo";
 
 export function useTodos() {
   const [todos, setTodos] = useState<Todo[]>([]);
+  const [archivedTodos, setArchivedTodos] = useState<Todo[]>([]);
   const [hydrated, setHydrated] = useState(false);
 
-  // Load todos from API on mount; fall back to localStorage if API is unavailable
   useEffect(() => {
     async function load() {
       try {
         const res = await fetch("/api/todos");
         if (res.ok) {
           const data: Todo[] = await res.json();
-          // If API store is empty, seed from localStorage
           if (data.length === 0 && typeof window !== "undefined") {
             const stored = localStorage.getItem("todos");
             if (stored) {
@@ -34,7 +33,6 @@ export function useTodos() {
           setTodos(data);
         }
       } catch {
-        // fallback to localStorage
         if (typeof window !== "undefined") {
           const stored = localStorage.getItem("todos");
           if (stored) setTodos(JSON.parse(stored));
@@ -46,7 +44,6 @@ export function useTodos() {
     load();
   }, []);
 
-  // Mirror to localStorage for offline resilience
   useEffect(() => {
     if (hydrated && typeof window !== "undefined") {
       localStorage.setItem("todos", JSON.stringify(todos));
@@ -58,22 +55,23 @@ export function useTodos() {
       title: string,
       priority: Todo["priority"],
       category?: Todo["category"],
-      dueDate?: string
+      dueDate?: string,
+      isRecurring?: boolean,
+      recurrencePattern?: RecurrencePattern,
+      recurrenceEndDate?: string
     ) => {
       try {
         const res = await fetch("/api/todos", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ title, priority, category, dueDate }),
+          body: JSON.stringify({ title, priority, category, dueDate, isRecurring, recurrencePattern, recurrenceEndDate }),
         });
         if (res.ok) {
           const todo: Todo = await res.json();
           setTodos((prev) => [todo, ...prev]);
           return;
         }
-      } catch {
-        // fallback: optimistic local add
-      }
+      } catch { /* fallback */ }
       const todo: Todo = {
         id: crypto.randomUUID(),
         title: title.trim(),
@@ -82,6 +80,9 @@ export function useTodos() {
         category,
         dueDate,
         createdAt: new Date().toISOString(),
+        isRecurring,
+        recurrencePattern,
+        recurrenceEndDate,
       };
       setTodos((prev) => [todo, ...prev]);
     },
@@ -90,9 +91,7 @@ export function useTodos() {
 
   const toggleTodo = useCallback(async (id: string) => {
     setTodos((prev) => {
-      const updated = prev.map((t) =>
-        t.id === id ? { ...t, completed: !t.completed } : t
-      );
+      const updated = prev.map((t) => (t.id === id ? { ...t, completed: !t.completed } : t));
       const todo = updated.find((t) => t.id === id);
       if (todo) {
         fetch(`/api/todos/${id}`, {
@@ -111,17 +110,9 @@ export function useTodos() {
   }, []);
 
   const editTodo = useCallback(
-    async (
-      id: string,
-      title: string,
-      priority: Todo["priority"],
-      category?: Todo["category"],
-      dueDate?: string
-    ) => {
+    async (id: string, title: string, priority: Todo["priority"], category?: Todo["category"], dueDate?: string) => {
       setTodos((prev) =>
-        prev.map((t) =>
-          t.id === id ? { ...t, title: title.trim(), priority, category, dueDate } : t
-        )
+        prev.map((t) => (t.id === id ? { ...t, title: title.trim(), priority, category, dueDate } : t))
       );
       fetch(`/api/todos/${id}`, {
         method: "PUT",
@@ -132,11 +123,64 @@ export function useTodos() {
     []
   );
 
+  const loadArchivedTodos = useCallback(async () => {
+    try {
+      const res = await fetch("/api/todos?archived=true");
+      if (res.ok) {
+        const data: Todo[] = await res.json();
+        setArchivedTodos(data);
+      }
+    } catch { /* silently fail */ }
+  }, []);
+
+  const archiveTodo = useCallback(async (id: string) => {
+    setTodos((prev) => {
+      const todo = prev.find((t) => t.id === id);
+      if (todo) {
+        const archived = { ...todo, archived: true, archivedAt: new Date().toISOString() };
+        setArchivedTodos((a) => [archived, ...a]);
+      }
+      return prev.filter((t) => t.id !== id);
+    });
+    fetch(`/api/todos/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: true }),
+    }).catch(() => {});
+  }, []);
+
+  const restoreTodo = useCallback(async (id: string) => {
+    setArchivedTodos((prev) => {
+      const todo = prev.find((t) => t.id === id);
+      if (todo) {
+        const restored = { ...todo, archived: false, archivedAt: undefined };
+        setTodos((t) => [restored, ...t]);
+      }
+      return prev.filter((t) => t.id !== id);
+    });
+    fetch(`/api/todos/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived: false }),
+    }).catch(() => {});
+  }, []);
+
+  const deleteArchivedTodo = useCallback(async (id: string) => {
+    setArchivedTodos((prev) => prev.filter((t) => t.id !== id));
+    fetch(`/api/todos/${id}`, { method: "DELETE" }).catch(() => {});
+  }, []);
+
   const clearCompleted = useCallback(async () => {
     setTodos((prev) => {
-      const toDelete = prev.filter((t) => t.completed);
-      toDelete.forEach((t) => {
-        fetch(`/api/todos/${t.id}`, { method: "DELETE" }).catch(() => {});
+      const toArchive = prev.filter((t) => t.completed);
+      toArchive.forEach((t) => {
+        const archived = { ...t, archived: true, archivedAt: new Date().toISOString() };
+        setArchivedTodos((a) => [archived, ...a]);
+        fetch(`/api/todos/${t.id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ archived: true }),
+        }).catch(() => {});
       });
       return prev.filter((t) => !t.completed);
     });
@@ -144,11 +188,16 @@ export function useTodos() {
 
   return {
     todos,
+    archivedTodos,
     hydrated,
     addTodo,
     toggleTodo,
     deleteTodo,
     editTodo,
+    archiveTodo,
+    restoreTodo,
+    deleteArchivedTodo,
+    loadArchivedTodos,
     clearCompleted,
   };
 }

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -9,5 +9,19 @@ export interface Todo {
   priority: Priority;
   category?: Category;
   dueDate?: string; // ISO date string YYYY-MM-DD
+  archived?: boolean;
+  archivedAt?: string;
+  sortOrder: number;
+  createdAt: string;
+}
+
+export interface Template {
+  id: string;
+  name: string;
+  title: string;
+  priority: Priority;
+  category?: Category;
+  archived?: boolean;
+  archivedAt?: string;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- Add file, image, and link attachment support to todo items
- Users can attach files (up to 5MB) including PDFs, images, and documents
- Users can attach links with custom display names
- Attachments display inline with image thumbnails, file icons, and clickable links
- Each attachment can be removed individually

## Changes
- **`src/types/todo.ts`** — Added `Attachment`, `AttachmentType` interfaces and `attachments` field on `Todo`
- **`prisma/schema.prisma`** — Added `attachments Json?` field to Todo model
- **`src/hooks/useTodos.ts`** — Added `addAttachment()` and `removeAttachment()` functions with optimistic updates
- **`src/app/api/todos/route.ts`** — Handle `attachments` in POST (create)
- **`src/app/api/todos/[id]/route.ts`** — Handle `attachments` in PUT (update)
- **`src/components/TodoItem.tsx`** — Full rewrite with attachment display, file upload button, link attachment form
- **`src/components/TodoApp.tsx`** — Pass `addAttachment`/`removeAttachment` handlers to `TodoItem`

## Testing
- Create a todo, hover over it, click the paperclip icon to attach a file
- Click the link icon to attach a URL
- Verify image attachments show thumbnails
- Verify file attachments show download links
- Verify link attachments open in new tab
- Verify attachments can be removed by hovering and clicking X
- Verify attachments persist after page reload

Closes #33