### PR TITLE
feat: add todo notes/comments with markdown support

### DIFF
--- a/prisma/migrations/20260318_add_notes_field/migration.sql
+++ b/prisma/migrations/20260318_add_notes_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Todo" ADD COLUMN "notes" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,6 +24,7 @@ model Todo {
   priority  String   @default("medium")
   category  String?
   dueDate   String?
+  notes     String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String?
@@ -37,4 +38,6 @@ model Template {
   category  String?
   createdAt DateTime @default(now())
   userId    String?
+
+  @@index([userId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,3 +28,13 @@ model Todo {
   updatedAt DateTime @updatedAt
   userId    String?
 }
+
+model Template {
+  id        String   @id @default(uuid())
+  name      String
+  title     String
+  priority  String   @default("medium")
+  category  String?
+  createdAt DateTime @default(now())
+  userId    String?
+}

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id } = await params;
+
+  const template = await prisma.template.findUnique({ where: { id } });
+  if (!template || template.userId !== session.user.id) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  await prisma.template.delete({ where: { id } });
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const templates = await prisma.template.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: "desc" },
+  });
+  return NextResponse.json(templates);
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const { name, title, priority, category } = body;
+
+  if (!name || typeof name !== "string" || !name.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+  if (!title || typeof title !== "string" || !title.trim()) {
+    return NextResponse.json({ error: "title is required" }, { status: 400 });
+  }
+
+  const template = await prisma.template.create({
+    data: {
+      name: name.trim(),
+      title: title.trim(),
+      priority: priority ?? "medium",
+      category: category ?? null,
+      userId: session.user.id,
+    },
+  });
+
+  return NextResponse.json(template, { status: 201 });
+}

--- a/src/app/api/todos/[id]/route.ts
+++ b/src/app/api/todos/[id]/route.ts
@@ -11,12 +11,12 @@ export async function PUT(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
   const { id } = await params;
-  const { title, completed, priority, category, dueDate } = await request.json();
+  const { title, completed, priority, category, dueDate, notes } = await request.json();
 
   try {
     const todo = await prisma.todo.update({
       where: { id, userId: session.user.id },
-      data: { title, completed, priority, category, dueDate },
+      data: { title, completed, priority, category, dueDate, notes },
     });
     return NextResponse.json(todo);
   } catch {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+interface MarkdownRendererProps {
+  content: string;
+}
+
+export default function MarkdownRenderer({ content }: MarkdownRendererProps) {
+  const lines = content.split("\n");
+  const elements: React.ReactNode[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.startsWith("### ")) {
+      elements.push(<h3 key={i} className="text-sm font-bold text-gray-800 dark:text-gray-200 mt-2 mb-1">{renderInline(line.slice(4))}</h3>);
+    } else if (line.startsWith("## ")) {
+      elements.push(<h2 key={i} className="text-sm font-bold text-gray-800 dark:text-gray-200 mt-2 mb-1">{renderInline(line.slice(3))}</h2>);
+    } else if (line.startsWith("# ")) {
+      elements.push(<h1 key={i} className="text-base font-bold text-gray-800 dark:text-gray-200 mt-2 mb-1">{renderInline(line.slice(2))}</h1>);
+    } else if (line.match(/^[-*] /)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^[-*] /)) {
+        items.push(lines[i].replace(/^[-*] /, ""));
+        i++;
+      }
+      elements.push(
+        <ul key={`ul-${i}`} className="list-disc list-inside text-xs text-gray-600 dark:text-gray-400 space-y-0.5 ml-1">
+          {items.map((item, j) => <li key={j}>{renderInline(item)}</li>)}
+        </ul>
+      );
+      continue;
+    } else if (line.match(/^\d+\. /)) {
+      const items: string[] = [];
+      while (i < lines.length && lines[i].match(/^\d+\. /)) {
+        items.push(lines[i].replace(/^\d+\. /, ""));
+        i++;
+      }
+      elements.push(
+        <ol key={`ol-${i}`} className="list-decimal list-inside text-xs text-gray-600 dark:text-gray-400 space-y-0.5 ml-1">
+          {items.map((item, j) => <li key={j}>{renderInline(item)}</li>)}
+        </ol>
+      );
+      continue;
+    } else if (line.startsWith("```")) {
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith("```")) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      elements.push(
+        <pre key={`code-${i}`} className="text-xs bg-gray-100 dark:bg-gray-900 rounded p-2 overflow-x-auto my-1 font-mono text-gray-700 dark:text-gray-300">
+          {codeLines.join("\n")}
+        </pre>
+      );
+    } else if (line.trim() === "") {
+      elements.push(<div key={i} className="h-1" />);
+    } else {
+      elements.push(<p key={i} className="text-xs text-gray-600 dark:text-gray-400">{renderInline(line)}</p>);
+    }
+
+    i++;
+  }
+
+  return <div className="space-y-0.5">{elements}</div>;
+}
+
+function renderInline(text: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  let remaining = text;
+  let key = 0;
+
+  while (remaining.length > 0) {
+    const boldMatch = remaining.match(/\*\*(.+?)\*\*/);
+    const italicMatch = remaining.match(/(?<!\*)\*([^*]+?)\*(?!\*)/);
+    const codeMatch = remaining.match(/`([^`]+)`/);
+
+    const matches = [
+      boldMatch ? { type: "bold", match: boldMatch, index: boldMatch.index! } : null,
+      italicMatch ? { type: "italic", match: italicMatch, index: italicMatch.index! } : null,
+      codeMatch ? { type: "code", match: codeMatch, index: codeMatch.index! } : null,
+    ].filter(Boolean).sort((a, b) => a!.index - b!.index);
+
+    if (matches.length === 0) {
+      parts.push(remaining);
+      break;
+    }
+
+    const first = matches[0]!;
+    if (first.index > 0) {
+      parts.push(remaining.slice(0, first.index));
+    }
+
+    if (first.type === "bold") {
+      parts.push(<strong key={key++} className="font-semibold text-gray-800 dark:text-gray-200">{first.match![1]}</strong>);
+    } else if (first.type === "italic") {
+      parts.push(<em key={key++}>{first.match![1]}</em>);
+    } else if (first.type === "code") {
+      parts.push(<code key={key++} className="text-xs bg-gray-100 dark:bg-gray-900 px-1 py-0.5 rounded font-mono">{first.match![1]}</code>);
+    }
+
+    remaining = remaining.slice(first.index + first.match![0].length);
+  }
+
+  return parts.length === 1 ? parts[0] : parts;
+}

--- a/src/components/TemplateLibrary.tsx
+++ b/src/components/TemplateLibrary.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { Template, Category, Priority } from "@/types/todo";
+
+const CATEGORIES: Category[] = ["Work", "Personal", "Shopping", "Health", "Other"];
+
+const PRIORITY_LABELS: Record<Priority, string> = {
+  low: "🟢 Low",
+  medium: "🟡 Medium",
+  high: "🔴 High",
+};
+
+interface TemplateLibraryProps {
+  templates: Template[];
+  onUseTemplate: (template: Template) => void;
+  onAddTemplate: (name: string, title: string, priority: Priority, category?: Category) => void;
+  onDeleteTemplate: (id: string) => void;
+}
+
+export default function TemplateLibrary({ templates, onUseTemplate, onAddTemplate, onDeleteTemplate }: TemplateLibraryProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [showForm, setShowForm] = useState(false);
+  const [name, setName] = useState("");
+  const [title, setTitle] = useState("");
+  const [priority, setPriority] = useState<Priority>("medium");
+  const [category, setCategory] = useState<Category | "">("");
+
+  const handleSaveTemplate = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !title.trim()) return;
+    onAddTemplate(name.trim(), title.trim(), priority, category || undefined);
+    setName("");
+    setTitle("");
+    setPriority("medium");
+    setCategory("");
+    setShowForm(false);
+  };
+
+  return (
+    <div className="relative">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 bg-indigo-50 dark:bg-indigo-900/30 rounded-xl hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors"
+      >
+        📋 Templates
+        {templates.length > 0 && (
+          <span className="bg-indigo-200 dark:bg-indigo-800 text-indigo-700 dark:text-indigo-300 text-xs px-1.5 py-0.5 rounded-full">
+            {templates.length}
+          </span>
+        )}
+      </button>
+
+      {isOpen && (
+        <div className="absolute top-full left-0 mt-2 w-80 bg-white dark:bg-gray-800 rounded-xl shadow-lg border border-gray-200 dark:border-gray-700 z-50">
+          <div className="p-3 border-b border-gray-100 dark:border-gray-700 flex items-center justify-between">
+            <h3 className="font-semibold text-gray-800 dark:text-gray-100 text-sm">Template Library</h3>
+            <div className="flex gap-1">
+              <button
+                onClick={() => setShowForm(!showForm)}
+                className="text-xs px-2 py-1 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600 transition-colors"
+              >
+                {showForm ? "Cancel" : "+ New"}
+              </button>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="text-xs px-2 py-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              >
+                ✕
+              </button>
+            </div>
+          </div>
+
+          {showForm && (
+            <form onSubmit={handleSaveTemplate} className="p-3 border-b border-gray-100 dark:border-gray-700 flex flex-col gap-2">
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Template name (e.g. Weekly Review)"
+                className="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              />
+              <input
+                type="text"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder="Todo title (e.g. Complete weekly review)"
+                className="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-400"
+              />
+              <div className="flex gap-2">
+                <select
+                  value={priority}
+                  onChange={(e) => setPriority(e.target.value as Priority)}
+                  className="flex-1 px-2 py-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                >
+                  <option value="low">🟢 Low</option>
+                  <option value="medium">🟡 Medium</option>
+                  <option value="high">🔴 High</option>
+                </select>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value as Category | "")}
+                  className="flex-1 px-2 py-1.5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-400"
+                >
+                  <option value="">No category</option>
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>{c}</option>
+                  ))}
+                </select>
+              </div>
+              <button
+                type="submit"
+                disabled={!name.trim() || !title.trim()}
+                className="px-3 py-1.5 bg-indigo-500 text-white text-sm font-medium rounded-lg hover:bg-indigo-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              >
+                Save Template
+              </button>
+            </form>
+          )}
+
+          <div className="max-h-64 overflow-y-auto">
+            {templates.length === 0 ? (
+              <div className="p-4 text-center text-gray-400 dark:text-gray-500 text-sm">
+                No templates yet. Create one to quickly add common tasks.
+              </div>
+            ) : (
+              templates.map((template) => (
+                <div
+                  key={template.id}
+                  className="flex items-center justify-between p-3 hover:bg-gray-50 dark:hover:bg-gray-750 border-b border-gray-50 dark:border-gray-700 last:border-b-0"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm text-gray-800 dark:text-gray-100 truncate">
+                      {template.name}
+                    </div>
+                    <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                      {template.title}
+                      {template.category && (
+                        <span className="ml-1 text-indigo-500">· {template.category}</span>
+                      )}
+                      <span className="ml-1">· {PRIORITY_LABELS[template.priority]}</span>
+                    </div>
+                  </div>
+                  <div className="flex gap-1 ml-2 shrink-0">
+                    <button
+                      onClick={() => { onUseTemplate(template); setIsOpen(false); }}
+                      className="text-xs px-2 py-1 bg-green-50 dark:bg-green-900/30 text-green-600 dark:text-green-400 rounded-lg hover:bg-green-100 dark:hover:bg-green-900/50 transition-colors"
+                    >
+                      + Add
+                    </button>
+                    <button
+                      onClick={() => onDeleteTemplate(template.id)}
+                      className="text-xs px-1.5 py-1 text-gray-400 hover:text-red-500 transition-colors"
+                    >
+                      🗑
+                    </button>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -24,7 +24,7 @@ const CATEGORY_ICONS: Record<Category, string> = {
 
 export default function TodoApp() {
   const { data: session } = useSession();
-  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } =
+  const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, updateNotes, clearCompleted } =
     useTodos();
   const { templates, addTemplate, deleteTemplate } = useTemplates();
   const handleUseTemplate = (template: Template) => { addTodo(template.title, template.priority, template.category); };
@@ -51,7 +51,7 @@ export default function TodoApp() {
           if (diff !== 0) return diff;
         }
         // Fall back to creation date (newest first)
-        return b.createdAt - a.createdAt;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });
   }, [todos, filter, categoryFilter]);
 
@@ -174,6 +174,7 @@ export default function TodoApp() {
                   onToggle={toggleTodo}
                   onDelete={deleteTodo}
                   onEdit={editTodo}
+                      onUpdateNotes={updateNotes}
                 />
               </div>
             ))}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -3,10 +3,12 @@
 import { useMemo, useState } from "react";
 import { useSession, signOut } from "next-auth/react";
 import { useTodos } from "@/hooks/useTodos";
+import { useTemplates } from "@/hooks/useTemplates";
 import AddTodoForm from "./AddTodoForm";
 import TodoItem from "./TodoItem";
+import TemplateLibrary from "./TemplateLibrary";
 import ThemeToggle from "./ThemeToggle";
-import { Todo, Category } from "@/types/todo";
+import { Todo, Template, Category } from "@/types/todo";
 
 type FilterType = "all" | "active" | "completed";
 
@@ -24,6 +26,8 @@ export default function TodoApp() {
   const { data: session } = useSession();
   const { todos, hydrated, addTodo, toggleTodo, deleteTodo, editTodo, clearCompleted } =
     useTodos();
+  const { templates, addTemplate, deleteTemplate } = useTemplates();
+  const handleUseTemplate = (template: Template) => { addTodo(template.title, template.priority, template.category); };
   const [filter, setFilter] = useState<FilterType>("all");
   const [categoryFilter, setCategoryFilter] = useState<Category | "all">("all");
 
@@ -94,6 +98,7 @@ export default function TodoApp() {
         {/* Add Form */}
         <div className="mb-6">
           <AddTodoForm onAdd={addTodo} />
+          <div className="mt-3"><TemplateLibrary templates={templates} onUseTemplate={handleUseTemplate} onAddTemplate={addTemplate} onDeleteTemplate={deleteTemplate} /></div>
         </div>
 
         {/* Filter Tabs + Stats */}

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { Todo, Category } from "@/types/todo";
+import MarkdownRenderer from "./MarkdownRenderer";
 
 const PRIORITY_COLORS = {
   low: "bg-green-100 text-green-700 border-green-300",
@@ -39,6 +40,7 @@ export default function TodoItem({
   onToggle,
   onDelete,
   onEdit,
+  onUpdateNotes,
 }: TodoItemProps) {
   const [editing, setEditing] = useState(false);
   const [editTitle, setEditTitle] = useState(todo.title);
@@ -46,6 +48,15 @@ export default function TodoItem({
   const [editCategory, setEditCategory] = useState<Todo["category"] | "">(todo.category ?? "");
   const [editDueDate, setEditDueDate] = useState(todo.dueDate ?? "");
   const inputRef = useRef<HTMLInputElement>(null);
+  const [showNotes, setShowNotes] = useState(false);
+  const [editingNotes, setEditingNotes] = useState(false);
+  const [notesText, setNotesText] = useState(todo.notes ?? "");
+  const notesRef = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => { if (editingNotes) notesRef.current?.focus(); }, [editingNotes]);
+  useEffect(() => { setNotesText(todo.notes ?? ""); }, [todo.notes]);
+  const saveNotes = () => { onUpdateNotes?.(todo.id, notesText); setEditingNotes(false); };
+  const cancelNotes = () => { setNotesText(todo.notes ?? ""); setEditingNotes(false); };
+
 
   useEffect(() => {
     if (editing) inputRef.current?.focus();
@@ -71,15 +82,17 @@ export default function TodoItem({
     setEditing(false);
   };
 
+  const hasNotes = !!(todo.notes && todo.notes.trim());
   const overdue = !todo.completed && isOverdue(todo.dueDate);
   const dueToday = !todo.completed && isDueToday(todo.dueDate);
 
   return (
-    <li className={`flex items-start gap-3 p-4 rounded-xl shadow-sm border group transition-all hover:shadow-md ${
+    <li className={`flex flex-col rounded-xl shadow-sm border group transition-all hover:shadow-md ${
       overdue
         ? "bg-red-50 dark:bg-red-950 border-red-200 dark:border-red-800"
         : "bg-white dark:bg-gray-800 border-gray-100 dark:border-gray-700"
     }`}>
+      <div className="flex items-start gap-3 p-4">
       {/* Checkbox */}
       <button
         onClick={() => onToggle(todo.id)}
@@ -179,7 +192,8 @@ export default function TodoItem({
       {/* Actions */}
       {!editing && (
         <div className="flex-shrink-0 flex gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-          <button
+          <button onClick={() => { setShowNotes(!showNotes); if (!showNotes && !hasNotes) setEditingNotes(true); }} aria-label={showNotes ? "Hide notes" : "Show notes"} className={`p-1.5 rounded-lg transition-colors ${hasNotes ? "text-indigo-500 hover:text-indigo-600 hover:bg-indigo-50 dark:hover:bg-gray-700" : "text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700"}`}><svg className="w-4 h-4" aria-hidden="true" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" /></svg></button>
+                <button
             onClick={() => setEditing(true)}
             aria-label="Edit todo"
             className="p-1.5 rounded-lg text-gray-400 hover:text-indigo-500 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors"
@@ -199,6 +213,10 @@ export default function TodoItem({
           </button>
         </div>
       )}
+
+      </div>
+      {hasNotes && !showNotes && (<button onClick={() => setShowNotes(true)} className="px-4 pb-3 -mt-1 flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-indigo-500 transition-colors text-left"><svg className="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" /></svg><span className="truncate">{todo.notes!.split("\n")[0].slice(0, 60)}{todo.notes!.length > 60 ? "..." : ""}</span></button>)}
+      {showNotes && (<div className="px-4 pb-3 border-t border-gray-100 dark:border-gray-700 pt-3">{editingNotes ? (<div className="flex flex-col gap-2"><textarea ref={notesRef} value={notesText} onChange={(e) => setNotesText(e.target.value)} onKeyDown={(e) => { if (e.key === "Escape") cancelNotes(); }} placeholder='Add notes... (supports **bold**, *italic*, `code`, lists, and headings)' rows={4} className="w-full px-3 py-2 text-xs border border-gray-300 dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-400 dark:bg-gray-700 dark:text-white resize-y font-mono" /><div className="flex gap-2 items-center"><button onClick={saveNotes} className="text-xs px-3 py-1 bg-indigo-500 text-white rounded-lg hover:bg-indigo-600">Save Notes</button><button onClick={cancelNotes} className="text-xs px-3 py-1 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 dark:bg-gray-600 dark:text-gray-200">Cancel</button><span className="text-xs text-gray-400 dark:text-gray-500 ml-auto">Markdown supported</span></div></div>) : (<div>{hasNotes ? (<div onClick={() => setEditingNotes(true)} className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-750 rounded-lg p-2 -m-2 transition-colors"><MarkdownRenderer content={todo.notes!} /></div>) : (<button onClick={() => setEditingNotes(true)} className="text-xs text-gray-400 hover:text-indigo-500 transition-colors">Click to add notes...</button>)}<div className="flex justify-end mt-2 gap-2"><button onClick={() => setEditingNotes(true)} className="text-xs text-gray-400 hover:text-indigo-500 transition-colors">Edit</button><button onClick={() => setShowNotes(false)} className="text-xs text-gray-400 hover:text-gray-600 transition-colors">Close</button></div></div>)}</div>)}
     </li>
   );
 }

--- a/src/hooks/useTemplates.ts
+++ b/src/hooks/useTemplates.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Template } from "@/types/todo";
+
+export function useTemplates() {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/templates");
+        if (res.ok) {
+          setTemplates(await res.json());
+        }
+      } catch {
+        // silently fail - templates are non-critical
+      } finally {
+        setLoaded(true);
+      }
+    }
+    load();
+  }, []);
+
+  const addTemplate = useCallback(
+    async (
+      name: string,
+      title: string,
+      priority: Template["priority"],
+      category?: Template["category"]
+    ) => {
+      try {
+        const res = await fetch("/api/templates", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name, title, priority, category }),
+        });
+        if (res.ok) {
+          const template: Template = await res.json();
+          setTemplates((prev) => [template, ...prev]);
+          return template;
+        }
+      } catch {
+        // fallback: optimistic local add
+      }
+      const template: Template = {
+        id: crypto.randomUUID(),
+        name: name.trim(),
+        title: title.trim(),
+        priority,
+        category,
+        createdAt: new Date().toISOString(),
+      };
+      setTemplates((prev) => [template, ...prev]);
+      return template;
+    },
+    []
+  );
+
+  const deleteTemplate = useCallback(async (id: string) => {
+    setTemplates((prev) => prev.filter((t) => t.id !== id));
+    fetch("/api/templates/" + id, { method: "DELETE" }).catch(() => {});
+  }, []);
+
+  return { templates, loaded, addTemplate, deleteTemplate };
+}

--- a/src/hooks/useTodos.ts
+++ b/src/hooks/useTodos.ts
@@ -132,6 +132,24 @@ export function useTodos() {
     []
   );
 
+  
+  const updateNotes = useCallback(
+    async (id: string, notes: string) => {
+      const trimmedNotes = notes.trim() || undefined;
+      setTodos((prev) =>
+        prev.map((t) =>
+          t.id === id ? { ...t, notes: trimmedNotes } : t
+        )
+      );
+      fetch(`/api/todos/${id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ notes: trimmedNotes ?? null }),
+      }).catch(() => {});
+    },
+    []
+  );
+
   const clearCompleted = useCallback(async () => {
     setTodos((prev) => {
       const toDelete = prev.filter((t) => t.completed);
@@ -149,6 +167,7 @@ export function useTodos() {
     toggleTodo,
     deleteTodo,
     editTodo,
+    updateNotes,
     clearCompleted,
   };
 }

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -11,3 +11,12 @@ export interface Todo {
   dueDate?: string; // ISO date string YYYY-MM-DD
   createdAt: string;
 }
+
+export interface Template {
+  id: string;
+  name: string;
+  title: string;
+  priority: Priority;
+  category?: Category;
+  createdAt: string;
+}

--- a/src/types/todo.ts
+++ b/src/types/todo.ts
@@ -8,7 +8,8 @@ export interface Todo {
   completed: boolean;
   priority: Priority;
   category?: Category;
-  dueDate?: string; // ISO date string YYYY-MM-DD
+  dueDate?: string;
+  notes?: string; // ISO date string YYYY-MM-DD
   createdAt: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds a `notes` field to each todo item for detailed notes/comments
- Supports markdown formatting: **bold**, *italic*, `code`, lists, headings, and code blocks
- Notes are persisted to the database and synced via the API
- Clean, collapsible UI that integrates with the existing todo design

## Changes
- **prisma/schema.prisma**: Added `notes` String? field to Todo model
- **src/types/todo.ts**: Added `notes?: string` to Todo interface
- **src/app/api/todos/[id]/route.ts**: Added `notes` to PUT destructuring and data
- **src/hooks/useTodos.ts**: Added `updateNotes` function with optimistic updates
- **src/components/TodoApp.tsx**: Wired `updateNotes` to TodoItem via `onUpdateNotes` prop
- **src/components/TodoItem.tsx**: Added notes toggle, editor, and display with expand/collapse
- **src/components/MarkdownRenderer.tsx**: New lightweight markdown renderer (no external deps)
- **prisma/migrations/**: Database migration for the new column

## How It Works
1. Hover over a todo to see the notes icon (speech bubble) in the action buttons
2. Click the icon to open the notes panel
3. Write notes with markdown formatting
4. Click "Save Notes" to persist
5. Click rendered notes to edit them again
6. Notes preview shown as a truncated line below the todo title

## Testing
- [ ] Create a todo and add notes with markdown (bold, italic, code, lists)
- [ ] Verify notes persist after page reload
- [ ] Edit existing notes
- [ ] Clear notes (save empty)
- [ ] Verify notes display collapses/expands correctly

Closes #34