### PR TITLE
feat: add email notifications for upcoming due dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "todo-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/adapter-pg": "^7.5.0",
         "@prisma/client": "^7.5.0",
@@ -14,6 +15,7 @@
         "bcryptjs": "^3.0.3",
         "next": "16.1.6",
         "next-auth": "^5.0.0-beta.30",
+        "nodemailer": "^7.0.7",
         "pg": "^8.20.0",
         "prisma": "^7.5.0",
         "react": "19.2.3",
@@ -22,6 +24,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/nodemailer": "^7.0.11",
         "@types/pg": "^8.18.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -2375,6 +2378,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-7.0.11.tgz",
+      "integrity": "sha512-E+U4RzR2dKrx+u3N4DlsmLaDC6mMZOM/TPROxA0UAPiTgI0y4CEFBmZE+coGWTjakDriRsXG368lNk1u9Q0a2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/pg": {
@@ -6370,6 +6383,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nypm": {
       "version": "0.6.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/nodemailer": "^7.0.11",
     "@types/pg": "^8.18.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "bcryptjs": "^3.0.3",
     "next": "16.1.6",
     "next-auth": "^5.0.0-beta.30",
+    "nodemailer": "^7.0.7",
     "pg": "^8.20.0",
     "prisma": "^7.5.0",
     "react": "19.2.3",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,6 @@ model Todo {
   priority  String   @default("medium")
   category  String?
   dueDate   String?
-  notes     String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String?
@@ -39,4 +38,14 @@ model NotificationPreference {
   lastNotifiedAt  DateTime?
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
+}
+
+model SentNotification {
+  id        String   @id @default(uuid())
+  todoId    String
+  userId    String
+  timing    String
+  createdAt DateTime @default(now())
+
+  @@unique([todoId, timing])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,7 +24,19 @@ model Todo {
   priority  String   @default("medium")
   category  String?
   dueDate   String?
+  notes     String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   userId    String?
+}
+
+model NotificationPreference {
+  id              String   @id @default(uuid())
+  userId          String   @unique
+  enabled         Boolean  @default(true)
+  emailAddress    String
+  remindAt        String[] @default(["1_day_before"])
+  lastNotifiedAt  DateTime?
+  createdAt       DateTime @default(now())
+  updatedAt       DateTime @updatedAt
 }

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+
+const VALID_REMIND_AT = ["1_hour_before", "1_day_before", "3_days_before"];
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const pref = await prisma.notificationPreference.findUnique({
+    where: { userId: session.user.id },
+  });
+  return NextResponse.json(pref ?? { enabled: false, emailAddress: "", remindAt: ["1_day_before"] });
+}
+
+export async function PUT(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const body = await request.json();
+  const { enabled, emailAddress, remindAt } = body;
+  if (typeof enabled !== "boolean") {
+    return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
+  }
+  if (enabled && (!emailAddress || typeof emailAddress !== "string" || !emailAddress.includes("@"))) {
+    return NextResponse.json({ error: "Valid email address is required" }, { status: 400 });
+  }
+  if (!Array.isArray(remindAt) || remindAt.some((r: string) => !VALID_REMIND_AT.includes(r))) {
+    return NextResponse.json({ error: "remindAt must be: " + VALID_REMIND_AT.join(", ") }, { status: 400 });
+  }
+  const pref = await prisma.notificationPreference.upsert({
+    where: { userId: session.user.id },
+    update: { enabled, emailAddress, remindAt },
+    create: { userId: session.user.id, enabled, emailAddress, remindAt },
+  });
+  return NextResponse.json(pref);
+}

--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/auth";
 import { prisma } from "@/lib/prisma";
 
 const VALID_REMIND_AT = ["1_hour_before", "1_day_before", "3_days_before"];
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export async function GET() {
   const session = await auth();
@@ -20,12 +21,17 @@ export async function PUT(request: NextRequest) {
   if (!session?.user?.id) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
-  const body = await request.json();
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
   const { enabled, emailAddress, remindAt } = body;
   if (typeof enabled !== "boolean") {
     return NextResponse.json({ error: "enabled must be a boolean" }, { status: 400 });
   }
-  if (enabled && (!emailAddress || typeof emailAddress !== "string" || !emailAddress.includes("@"))) {
+  if (enabled && (!emailAddress || typeof emailAddress !== "string" || !EMAIL_REGEX.test(emailAddress))) {
     return NextResponse.json({ error: "Valid email address is required" }, { status: 400 });
   }
   if (!Array.isArray(remindAt) || remindAt.some((r: string) => !VALID_REMIND_AT.includes(r))) {

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { sendReminderEmail } from "@/lib/email";
+
+export async function POST(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== "Bearer " + process.env.CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const now = new Date();
+  const prefs = await prisma.notificationPreference.findMany({ where: { enabled: true } });
+  let sent = 0;
+  for (const pref of prefs) {
+    const todos = await prisma.todo.findMany({
+      where: { userId: pref.userId, completed: false, dueDate: { not: null } },
+    });
+    for (const todo of todos) {
+      if (!todo.dueDate) continue;
+      const dueDate = new Date(todo.dueDate + "T00:00:00");
+      const diffHours = (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60);
+      for (const timing of pref.remindAt) {
+        let shouldNotify = false;
+        if (timing === "1_hour_before" && diffHours > 0 && diffHours <= 1) shouldNotify = true;
+        else if (timing === "1_day_before" && diffHours > 0 && diffHours <= 24) shouldNotify = true;
+        else if (timing === "3_days_before" && diffHours > 0 && diffHours <= 72) shouldNotify = true;
+        if (shouldNotify) {
+          try {
+            await sendReminderEmail({ to: pref.emailAddress, todoTitle: todo.title, dueDate: todo.dueDate, reminderType: timing });
+            sent++;
+          } catch (err) {
+            console.error("Failed to send reminder for todo " + todo.id + ":", err);
+          }
+        }
+      }
+    }
+    await prisma.notificationPreference.update({ where: { id: pref.id }, data: { lastNotifiedAt: now } });
+  }
+  return NextResponse.json({ sent, checkedUsers: prefs.length });
+}

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -1,31 +1,76 @@
 import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
 import { prisma } from "@/lib/prisma";
 import { sendReminderEmail } from "@/lib/email";
 
+function verifySecret(header: string | null): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+
+  const expected = "Bearer " + secret;
+  if (!header || header.length !== expected.length) return false;
+
+  return crypto.timingSafeEqual(
+    Buffer.from(header),
+    Buffer.from(expected),
+  );
+}
+
 export async function POST(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== "Bearer " + process.env.CRON_SECRET) {
+  if (!verifySecret(request.headers.get("authorization"))) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
   const now = new Date();
   const prefs = await prisma.notificationPreference.findMany({ where: { enabled: true } });
+
+  if (prefs.length === 0) {
+    return NextResponse.json({ sent: 0, checkedUsers: 0 });
+  }
+
+  const userIds = prefs.map((p) => p.userId);
+
+  const allTodos = await prisma.todo.findMany({
+    where: { userId: { in: userIds }, completed: false, dueDate: { not: null } },
+  });
+
+  const todosByUser = new Map<string, typeof allTodos>();
+  for (const todo of allTodos) {
+    const list = todosByUser.get(todo.userId!) ?? [];
+    list.push(todo);
+    todosByUser.set(todo.userId!, list);
+  }
+
+  const existingSent = await prisma.sentNotification.findMany({
+    where: {
+      todoId: { in: allTodos.map((t) => t.id) },
+    },
+  });
+  const alreadySent = new Set(existingSent.map((s) => s.todoId + ":" + s.timing));
+
   let sent = 0;
+  const notificationsToCreate: { todoId: string; userId: string; timing: string }[] = [];
+
   for (const pref of prefs) {
-    const todos = await prisma.todo.findMany({
-      where: { userId: pref.userId, completed: false, dueDate: { not: null } },
-    });
+    const todos = todosByUser.get(pref.userId) ?? [];
     for (const todo of todos) {
       if (!todo.dueDate) continue;
       const dueDate = new Date(todo.dueDate + "T00:00:00");
       const diffHours = (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60);
+
       for (const timing of pref.remindAt) {
+        const key = todo.id + ":" + timing;
+        if (alreadySent.has(key)) continue;
+
         let shouldNotify = false;
         if (timing === "1_hour_before" && diffHours > 0 && diffHours <= 1) shouldNotify = true;
         else if (timing === "1_day_before" && diffHours > 0 && diffHours <= 24) shouldNotify = true;
         else if (timing === "3_days_before" && diffHours > 0 && diffHours <= 72) shouldNotify = true;
+
         if (shouldNotify) {
           try {
             await sendReminderEmail({ to: pref.emailAddress, todoTitle: todo.title, dueDate: todo.dueDate, reminderType: timing });
+            notificationsToCreate.push({ todoId: todo.id, userId: pref.userId, timing });
             sent++;
           } catch (err) {
             console.error("Failed to send reminder for todo " + todo.id + ":", err);
@@ -35,5 +80,10 @@ export async function POST(request: NextRequest) {
     }
     await prisma.notificationPreference.update({ where: { id: pref.id }, data: { lastNotifiedAt: now } });
   }
+
+  if (notificationsToCreate.length > 0) {
+    await prisma.sentNotification.createMany({ data: notificationsToCreate });
+  }
+
   return NextResponse.json({ sent, checkedUsers: prefs.length });
 }

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+interface NotificationPref {
+  enabled: boolean;
+  emailAddress: string;
+  remindAt: string[];
+}
+
+const REMINDER_OPTIONS = [
+  { value: "1_hour_before", label: "1 hour before" },
+  { value: "1_day_before", label: "1 day before" },
+  { value: "3_days_before", label: "3 days before" },
+];
+
+export default function NotificationSettings() {
+  const [open, setOpen] = useState(false);
+  const [pref, setPref] = useState<NotificationPref>({ enabled: false, emailAddress: "", remindAt: ["1_day_before"] });
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState("");
+  const loadPrefs = useCallback(async () => {
+    try {
+      const res = await fetch("/api/notifications/preferences");
+      if (res.ok) {
+        const data = await res.json();
+        setPref({ enabled: data.enabled ?? false, emailAddress: data.emailAddress ?? "", remindAt: data.remindAt ?? ["1_day_before"] });
+      }
+    } catch { /* ignore */ }
+  }, []);
+  useEffect(() => { if (open) loadPrefs(); }, [open, loadPrefs]);
+  const handleSave = async () => {
+    setSaving(true); setMessage("");
+    try {
+      const res = await fetch("/api/notifications/preferences", { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(pref) });
+      if (res.ok) { setMessage("Settings saved!"); } else { const err = await res.json(); setMessage(err.error ?? "Failed to save"); }
+    } catch { setMessage("Failed to save settings"); } finally { setSaving(false); }
+  };
+  const toggleRemindAt = (value: string) => {
+    setPref((prev) => ({ ...prev, remindAt: prev.remindAt.includes(value) ? prev.remindAt.filter((r) => r !== value) : [...prev.remindAt, value] }));
+  };
+  if (!open) {
+    return (
+      <button onClick={() => setOpen(true)} className="text-xs text-gray-400 hover:text-indigo-500 transition-colors flex items-center gap-1" title="Notification settings">
+        <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" /></svg>
+      </button>
+    );
+  }
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl max-w-md w-full p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-gray-800 dark:text-gray-100">Email Notifications</h2>
+          <button onClick={() => setOpen(false)} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}><path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+          </button>
+        </div>
+        <div className="space-y-4">
+          <label className="flex items-center gap-3 cursor-pointer">
+            <input type="checkbox" checked={pref.enabled} onChange={(e) => setPref((p) => ({ ...p, enabled: e.target.checked }))} className="w-4 h-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400" />
+            <span className="text-sm text-gray-700 dark:text-gray-300">Enable email reminders for due dates</span>
+          </label>
+          {pref.enabled && (<>
+            <div>
+              <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">Email address</label>
+              <input type="email" value={pref.emailAddress} onChange={(e) => setPref((p) => ({ ...p, emailAddress: e.target.value }))} placeholder="you@example.com" className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-800 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-400 text-sm" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-600 dark:text-gray-400 mb-2">Remind me</label>
+              <div className="space-y-2">
+                {REMINDER_OPTIONS.map(({ value, label }) => (
+                  <label key={value} className="flex items-center gap-2 cursor-pointer">
+                    <input type="checkbox" checked={pref.remindAt.includes(value)} onChange={() => toggleRemindAt(value)} className="w-4 h-4 rounded border-gray-300 text-indigo-500 focus:ring-indigo-400" />
+                    <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </>)}
+          <button onClick={handleSave} disabled={saving || (pref.enabled && pref.remindAt.length === 0)} className="w-full px-4 py-2 bg-indigo-500 text-white font-medium rounded-lg hover:bg-indigo-600 disabled:opacity-40 disabled:cursor-not-allowed transition-colors text-sm">{saving ? "Saving..." : "Save Settings"}</button>
+          {message && <p className={"text-xs text-center " + (message.includes("saved") ? "text-green-500" : "text-red-500")}>{message}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -48,7 +48,7 @@ export default function TodoApp() {
           if (diff !== 0) return diff;
         }
         // Fall back to creation date (newest first)
-        return b.createdAt - a.createdAt;
+        return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       });
   }, [todos, filter, categoryFilter]);
 

--- a/src/components/TodoApp.tsx
+++ b/src/components/TodoApp.tsx
@@ -6,6 +6,7 @@ import { useTodos } from "@/hooks/useTodos";
 import AddTodoForm from "./AddTodoForm";
 import TodoItem from "./TodoItem";
 import ThemeToggle from "./ThemeToggle";
+import NotificationSettings from "./NotificationSettings";
 import { Todo, Category } from "@/types/todo";
 
 type FilterType = "all" | "active" | "completed";
@@ -71,6 +72,7 @@ export default function TodoApp() {
             </h1>
             <div className="flex items-center gap-3">
               <ThemeToggle />
+              <NotificationSettings />
               {session?.user && (
                 <>
                   <span className="text-sm text-gray-600 dark:text-gray-400">

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,5 +1,14 @@
 import nodemailer from "nodemailer";
 
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST ?? "smtp.gmail.com",
   port: Number(process.env.SMTP_PORT ?? 587),
@@ -36,6 +45,6 @@ export async function sendReminderEmail({
     from: process.env.SMTP_FROM ?? "Todo App <noreply@todoapp.com>",
     to,
     subject: `Reminder: "${todoTitle}" is due in ${label}`,
-    html: '<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;"><h2 style="color: #4f46e5;">Todo Reminder</h2><p>Your task <strong>"' + todoTitle + '"</strong> is due in <strong>' + label + '</strong>.</p><p style="color: #6b7280;">Due date: ' + dueDate + '</p><hr style="border: none; border-top: 1px solid #e5e7eb;" /><p style="color: #9ca3af; font-size: 12px;">You received this because you have email notifications enabled in your Todo App settings.</p></div>',
+    html: '<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;"><h2 style="color: #4f46e5;">Todo Reminder</h2><p>Your task <strong>"' + escapeHtml(todoTitle) + '"</strong> is due in <strong>' + escapeHtml(label) + '</strong>.</p><p style="color: #6b7280;">Due date: ' + escapeHtml(dueDate) + '</p><hr style="border: none; border-top: 1px solid #e5e7eb;" /><p style="color: #9ca3af; font-size: 12px;">You received this because you have email notifications enabled in your Todo App settings.</p></div>',
   });
 }

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,41 @@
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST ?? "smtp.gmail.com",
+  port: Number(process.env.SMTP_PORT ?? 587),
+  secure: process.env.SMTP_SECURE === "true",
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+interface ReminderEmailParams {
+  to: string;
+  todoTitle: string;
+  dueDate: string;
+  reminderType: string;
+}
+
+export async function sendReminderEmail({
+  to,
+  todoTitle,
+  dueDate,
+  reminderType,
+}: ReminderEmailParams) {
+  const label =
+    reminderType === "1_hour_before"
+      ? "1 hour"
+      : reminderType === "1_day_before"
+        ? "1 day"
+        : reminderType === "3_days_before"
+          ? "3 days"
+          : reminderType;
+
+  await transporter.sendMail({
+    from: process.env.SMTP_FROM ?? "Todo App <noreply@todoapp.com>",
+    to,
+    subject: `Reminder: "${todoTitle}" is due in ${label}`,
+    html: '<div style="font-family: sans-serif; max-width: 480px; margin: 0 auto;"><h2 style="color: #4f46e5;">Todo Reminder</h2><p>Your task <strong>"' + todoTitle + '"</strong> is due in <strong>' + label + '</strong>.</p><p style="color: #6b7280;">Due date: ' + dueDate + '</p><hr style="border: none; border-top: 1px solid #e5e7eb;" /><p style="color: #9ca3af; font-size: 12px;">You received this because you have email notifications enabled in your Todo App settings.</p></div>',
+  });
+}


### PR DESCRIPTION
## Summary
- Add email notification system for upcoming todo due dates
- Users can configure notification preferences (1 hour, 1 day, or 3 days before)
- Add notification settings UI accessible from the app header (bell icon)
- Add cron-compatible API endpoint for triggering reminder emails

## Changes
- **Prisma schema**: Added `NotificationPreference` model to store user notification settings
- **package.json**: Added `nodemailer` dependency for email sending
- **`src/lib/email.ts`**: Email utility with HTML-formatted reminder emails via SMTP
- **`src/app/api/notifications/preferences/route.ts`**: GET/PUT API for managing user notification preferences with input validation
- **`src/app/api/notifications/send/route.ts`**: POST endpoint (secured with `CRON_SECRET`) that checks all users' todos against their notification preferences and sends reminder emails
- **`src/components/NotificationSettings.tsx`**: Modal component for configuring email, enabling/disabling notifications, and selecting reminder timing
- **`src/components/TodoApp.tsx`**: Integrated notification settings button in the header
- **`src/components/TodoApp.tsx`**: Fixed pre-existing TypeScript error in `createdAt` sort comparison

## Environment Variables Required
- `SMTP_HOST` - SMTP server host (defaults to smtp.gmail.com)
- `SMTP_PORT` - SMTP port (defaults to 587)
- `SMTP_SECURE` - Use TLS (defaults to false)
- `SMTP_USER` - SMTP username
- `SMTP_PASS` - SMTP password
- `SMTP_FROM` - From address for emails
- `CRON_SECRET` - Bearer token to authenticate the send endpoint

## Testing
- Open the app and click the bell icon next to the theme toggle
- Toggle notifications on, enter an email, select reminder timings
- Save settings and verify they persist on reload
- To trigger notifications, POST to `/api/notifications/send` with `Authorization: Bearer <CRON_SECRET>`

Closes #37