### PR TITLE
fix: address QA feedback on notification timing bugs

### DIFF
--- a/src/app/api/notifications/preferences/route.ts
+++ b/src/app/api/notifications/preferences/route.ts
@@ -34,7 +34,7 @@ export async function PUT(request: NextRequest) {
   if (enabled && (!emailAddress || typeof emailAddress !== "string" || !EMAIL_REGEX.test(emailAddress))) {
     return NextResponse.json({ error: "Valid email address is required" }, { status: 400 });
   }
-  if (!Array.isArray(remindAt) || remindAt.some((r: string) => !VALID_REMIND_AT.includes(r))) {
+  if (!Array.isArray(remindAt) || remindAt.length === 0 || remindAt.some((r: string) => !VALID_REMIND_AT.includes(r))) {
     return NextResponse.json({ error: "remindAt must be: " + VALID_REMIND_AT.join(", ") }, { status: 400 });
   }
   const pref = await prisma.notificationPreference.upsert({

--- a/src/app/api/notifications/send/route.ts
+++ b/src/app/api/notifications/send/route.ts
@@ -50,12 +50,13 @@ export async function POST(request: NextRequest) {
 
   let sent = 0;
   const notificationsToCreate: { todoId: string; userId: string; timing: string }[] = [];
+  const usersNotified = new Set<string>();
 
   for (const pref of prefs) {
     const todos = todosByUser.get(pref.userId) ?? [];
     for (const todo of todos) {
       if (!todo.dueDate) continue;
-      const dueDate = new Date(todo.dueDate + "T00:00:00");
+      const dueDate = new Date(todo.dueDate + "T00:00:00Z");
       const diffHours = (dueDate.getTime() - now.getTime()) / (1000 * 60 * 60);
 
       for (const timing of pref.remindAt) {
@@ -71,6 +72,7 @@ export async function POST(request: NextRequest) {
           try {
             await sendReminderEmail({ to: pref.emailAddress, todoTitle: todo.title, dueDate: todo.dueDate, reminderType: timing });
             notificationsToCreate.push({ todoId: todo.id, userId: pref.userId, timing });
+            usersNotified.add(pref.id);
             sent++;
           } catch (err) {
             console.error("Failed to send reminder for todo " + todo.id + ":", err);
@@ -78,7 +80,9 @@ export async function POST(request: NextRequest) {
         }
       }
     }
-    await prisma.notificationPreference.update({ where: { id: pref.id }, data: { lastNotifiedAt: now } });
+    if (usersNotified.has(pref.id)) {
+      await prisma.notificationPreference.update({ where: { id: pref.id }, data: { lastNotifiedAt: now } });
+    }
   }
 
   if (notificationsToCreate.length > 0) {


### PR DESCRIPTION
## Summary
Follow-up to PR #59 addressing remaining QA feedback on the notification system.

## Changes
- **Timezone fix** (`send/route.ts:59`): Changed `T00:00:00` to `T00:00:00Z` so due dates are parsed as UTC, matching `new Date()` behavior on production servers
- **lastNotifiedAt guard** (`send/route.ts:83-85`): Only updates `lastNotifiedAt` when at least one email was actually sent for that user, preventing false "notified" timestamps
- **Empty remindAt validation** (`preferences/route.ts:37`): Rejects empty `remindAt` arrays to prevent saving preferences with no reminder timings selected

## Testing
- Deploy to a non-UTC server and verify notification timing is correct
- Run the cron endpoint with users who have no upcoming due todos — verify `lastNotifiedAt` is NOT updated
- Try saving preferences with an empty `remindAt` array — should return 400

Relates to #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)